### PR TITLE
fix(cosmos): Remove temporary workaround for azurerm v2

### DIFF
--- a/cosmosdb_sql_container/main.tf
+++ b/cosmosdb_sql_container/main.tf
@@ -15,13 +15,6 @@ resource "azurerm_cosmosdb_sql_container" "this" {
     }
   }
 
-  # this is a temp workaournd until azurerm 3.0 because azurerm 2.99 minimum value is 4000
-  lifecycle {
-    ignore_changes = [
-      autoscale_settings,
-    ]
-  }
-
   dynamic "autoscale_settings" {
     for_each = var.autoscale_settings != null ? [var.autoscale_settings] : []
     content {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Remove lifecycle rule ignoring autoscale settings

### Motivation and context

This was a temporary workaround due to the limitation of azurerm v2.

Since this repo works only on azurerm v3, we can remove the workaround.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
