### PR TITLE
breaking: Devops 870 azurerm app service and app service slot modules update

### DIFF
--- a/app_service/README.md
+++ b/app_service/README.md
@@ -56,7 +56,7 @@ Of course, the values listed above may change in the future, so please check whi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.30.0, <= 3.45.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.39.0, <= 3.45.0 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No modules.
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the resource group in which to create the App Service and App Service Plan. | `string` | n/a | yes |
 | <a name="input_ruby_version"></a> [ruby\_version](#input\_ruby\_version) | n/a | `string` | `null` | no |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | (Required) The SKU for the plan. | `string` | `null` | no |
+| <a name="input_sticky_settings"></a> [sticky\_settings](#input\_sticky\_settings) | (Optional) A list of app\_setting names that the Linux Function App will not swap between Slots when a swap operation is triggered | `list(string)` | `[]` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Optional) Subnet id wether you want to integrate the app service to a subnet. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
 | <a name="input_use_32_bit_worker_process"></a> [use\_32\_bit\_worker\_process](#input\_use\_32\_bit\_worker\_process) | (Optional) Should the Function App run in 32 bit mode, rather than 64 bit mode? Defaults to false. | `bool` | `false` | no |

--- a/app_service/README.md
+++ b/app_service/README.md
@@ -148,7 +148,7 @@ Is mandatory to setup this two env variables, to enable internal dns:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.44.1 |
 
 ## Modules
 

--- a/app_service/README.md
+++ b/app_service/README.md
@@ -1,139 +1,53 @@
-# app service
+# App service
 
-This module allow the creation of an app service
-
-## Architecture
-
-![This is an image](./docs/module-arch.drawio.png)
-
-## Configurations
-
-### Mandatory configurations
-
-#### app_settings
-
-Is mandatory to setup this two env variables, to enable internal dns:
-
-> Integration with private DNS (see more: <https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html>)
-
-* `WEBSITE_DNS_SERVER` with value 168.63.129.16
-* `WEBSITE_VNET_ROUTE_ALL` with value 1
+This module allow the creation of an app service.
+In terraform output you can get the the app service's name and id.
 
 ## How to use it
+Use the example Terraform template, saved in `./tests`, to test this module and get some advices.
 
-### Docker Version
-
-```ts
-  resource "azurerm_resource_group" "app_service_docker_rg" {
-    name     = "${local.program}-app-service-docker-rg"
-    location = var.location
-
-    tags = var.tags
-  }
-
-  # Subnet to host the api config
-  module "app_service_docker_snet" {
-    source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.11.0"
-    name                 = "${local.program}-app-docker-snet"
-    address_prefixes     = var.cidr_subnet_app_docker
-    virtual_network_name = data.azurerm_virtual_network.vnet.name
-
-    resource_group_name = data.azurerm_resource_group.rg_vnet.name
-
-    private_endpoint_network_policies_enabled = true
-    service_endpoints                         = ["Microsoft.Web"]
-  }
-
-  locals {
-    apiconfig_cors_configuration = {
-      origins = ["*"]
-      methods = ["*"]
-    }
-  }
-
-  resource "azurerm_app_service_plan" "app_docker" {
-
-    count = var.is_web_app_service_docker_enabled ? 1 : 0
-
-    name                = "${local.program}-plan-app-service-docker"
-    location            = var.location
-    resource_group_name = azurerm_resource_group.app_service_docker_rg.name
-
-    kind = "Linux"
-
-    sku {
-      tier = "Basic"
-      size = "B1"
-    }
-    reserved = true
-
-    tags = var.tags
-  }
-
-  module "web_app_service_docker" {
-    count = var.is_web_app_service_docker_enabled ? 1 : 0
-
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service?ref=v3.11.0"
-
-    resource_group_name = azurerm_resource_group.app_service_docker_rg.name
-    location            = var.location
-
-    plan_type = "external"
-    plan_id   = azurerm_app_service_plan.app_docker[0].id
-
-    # App service plan
-    name                = "${local.program}-app-service-docker"
-    client_cert_enabled = false
-    always_on           = false
-    linux_fx_version    = "DOCKER|${data.azurerm_container_registry.acr.login_server}/devopswebapppython:latest"
-    health_check_path   = "/status"
-
-    app_settings = {
-      # Monitoring
-      APPINSIGHTS_INSTRUMENTATIONKEY                  = data.azurerm_application_insights.application_insights.instrumentation_key
-      APPLICATIONINSIGHTS_CONNECTION_STRING           = "InstrumentationKey=${data.azurerm_application_insights.application_insights.instrumentation_key}"
-      APPINSIGHTS_PROFILERFEATURE_VERSION             = "1.0.0"
-      APPINSIGHTS_SNAPSHOTFEATURE_VERSION             = "1.0.0"
-      APPLICATIONINSIGHTS_CONFIGURATION_CONTENT       = ""
-      ApplicationInsightsAgent_EXTENSION_VERSION      = "~3"
-      DiagnosticServices_EXTENSION_VERSION            = "~3"
-      InstrumentationEngine_EXTENSION_VERSION         = "disabled"
-      SnapshotDebugger_EXTENSION_VERSION              = "disabled"
-      XDT_MicrosoftApplicationInsights_BaseExtensions = "disabled"
-      XDT_MicrosoftApplicationInsights_Mode           = "recommended"
-      XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
-      WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
-      TIMEOUT_DELAY                                   = 300
-      # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
-      WEBSITE_DNS_SERVER = "168.63.129.16"
-      # Spring Environment
-
-      WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
-      WEBSITES_PORT                       = 8000
-      # DOCKER_REGISTRY_SERVER_URL      = "https://${module.acr[0].login_server}"
-      # DOCKER_REGISTRY_SERVER_USERNAME = module.acr[0].admin_username
-      # DOCKER_REGISTRY_SERVER_PASSWORD = module.acr[0].admin_password
-    }
-
-    allowed_subnets = [module.apim_snet.id]
-    allowed_ips     = []
-
-    subnet_id = module.app_service_docker_snet.id
-
-    tags = var.tags
-  }
-
-  #
-  # Role assignments
-  #
-  resource "azurerm_role_assignment" "webapp_docker_to_acr" {
-    count = var.is_web_app_service_docker_enabled ? 1 : 0
-
-    scope                = data.azurerm_container_registry.acr.id
-    role_definition_name = "AcrPull"
-    principal_id         = module.web_app_service_docker[0].principal_id
-  }
+## How to migrate from `azurerm_app_service` to `azurerm_linux_web_app`
+The script tests/migrate.sh will remove and import the deprecated resources as new ones.
+You need to know the resource old and new names.
 ```
+e.g.
+# app_service resources to migrate
+cd tests
+./migrate.sh module.web_app_service_docker.azurerm_app_service.this module.web_app_service_docker.azurerm_linux_web_app.this
+./migrate.sh azurerm_app_service_plan.app_docker azurerm_service_plan.app_docker
+
+# app_service_slot resource to migrate
+./migrate.sh module.web_app_service_slot_docker.azurerm_app_service_slot.this module.web_app_service_slot_docker.azurerm_linux_web_app_slot.this
+```
+
+## Note about migrating from `azurerm_app_service` to `azurerm_linux_web_app`
+
+Since the resource `azurerm_app_service` has been deprecated in version 3.0 of the AzureRM provider, the newer `azurerm_linux_web_app` resource is used in this module, thus the following variables have been:
+
+removed:
+- os_type
+- app_service_plan_info/sku_tier
+- linux_fx_version
+- app_service_plan_id
+
+replaced:
+- min_tls_version -> minimum_tls_version
+- client_cert_enabled -> client_certificate_enabled
+
+## How to configure the Linux framework
+
+Don't use `linux_fx_version` anymore.
+Now you need to specify **only** one variable of the following list:
+- docker - (Optional) One or more docker blocks as defined below.
+- dotnet_version - (Optional) The version of .NET to use. Possible values include 3.1, 6.0 and 7.0.
+- use_dotnet_isolated_runtime - (Optional) Should the DotNet process use an isolated runtime. Defaults to false.
+- java_version - (Optional) The Version of Java to use. Supported versions include 8, 11 & 17 (In-Preview).
+- node_version - (Optional) The version of Node to run. Possible values include 12, 14, 16 and 18.
+- python_version - (Optional) The version of Python to run. Possible values are 3.10, 3.9, 3.8 and 3.7.
+- powershell_core_version - (Optional) The version of PowerShell Core to run. Possible values are 7, and 7.2.
+- use_custom_runtime - (Optional) Should the Linux Function App use a custom runtime?
+
+Of course, the values listed above may change in the future, so please check which ones are still valid.
 
 <!-- markdownlint-disable -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -148,7 +62,7 @@ Is mandatory to setup this two env variables, to enable internal dns:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.44.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
 
 ## Modules
 
@@ -158,9 +72,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_app_service.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service) | resource |
-| [azurerm_app_service_plan.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_plan) | resource |
 | [azurerm_app_service_virtual_network_swift_connection.app_service_virtual_network_swift_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_virtual_network_swift_connection) | resource |
+| [azurerm_linux_web_app.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) | resource |
+| [azurerm_service_plan.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
 
 ## Inputs
 
@@ -173,24 +87,33 @@ No modules.
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | n/a | `map(string)` | `{}` | no |
 | <a name="input_client_affinity_enabled"></a> [client\_affinity\_enabled](#input\_client\_affinity\_enabled) | (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance? Defaults to false. | `bool` | `false` | no |
 | <a name="input_client_cert_enabled"></a> [client\_cert\_enabled](#input\_client\_cert\_enabled) | (Optional) Does the App Service require client certificates for incoming requests? Defaults to false. | `bool` | `false` | no |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Framework choice | `string` | `null` | no |
+| <a name="input_docker_image_tag"></a> [docker\_image\_tag](#input\_docker\_image\_tag) | n/a | `string` | `null` | no |
+| <a name="input_dotnet_version"></a> [dotnet\_version](#input\_dotnet\_version) | n/a | `string` | `null` | no |
 | <a name="input_ftps_state"></a> [ftps\_state](#input\_ftps\_state) | (Optional) Enable FTPS connection ( Default: Disabled ) | `string` | `"Disabled"` | no |
+| <a name="input_go_version"></a> [go\_version](#input\_go\_version) | n/a | `string` | `null` | no |
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | (Optional) The health check path to be pinged by App Service. | `string` | `null` | no |
 | <a name="input_https_only"></a> [https\_only](#input\_https\_only) | (Optional) Can the App Service only be accessed via HTTPS? Defaults to true. | `bool` | `true` | no |
-| <a name="input_linux_fx_version"></a> [linux\_fx\_version](#input\_linux\_fx\_version) | (Optional) Linux App Framework and version for the App Service. | `string` | `null` | no |
+| <a name="input_java_server"></a> [java\_server](#input\_java\_server) | n/a | `string` | `null` | no |
+| <a name="input_java_server_version"></a> [java\_server\_version](#input\_java\_server\_version) | n/a | `string` | `null` | no |
+| <a name="input_java_version"></a> [java\_version](#input\_java\_version) | n/a | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | `"westeurope"` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) Specifies the name of the App Service. Changing this forces a new resource to be created. | `string` | n/a | yes |
+| <a name="input_node_version"></a> [node\_version](#input\_node\_version) | n/a | `string` | `null` | no |
+| <a name="input_php_version"></a> [php\_version](#input\_php\_version) | n/a | `string` | `null` | no |
 | <a name="input_plan_id"></a> [plan\_id](#input\_plan\_id) | (Optional only if plan\_type=internal) Specifies the external app service plan id. | `string` | `null` | no |
 | <a name="input_plan_kind"></a> [plan\_kind](#input\_plan\_kind) | (Optional) The kind of the App Service Plan to create. Possible values are Windows (also available as App), Linux, elastic (for Premium Consumption) and FunctionApp (for a Consumption Plan). Changing this forces a new resource to be created. | `string` | `null` | no |
 | <a name="input_plan_maximum_elastic_worker_count"></a> [plan\_maximum\_elastic\_worker\_count](#input\_plan\_maximum\_elastic\_worker\_count) | (Optional) The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan. | `number` | `null` | no |
 | <a name="input_plan_name"></a> [plan\_name](#input\_plan\_name) | (Optional) Specifies the name of the App Service Plan component. Changing this forces a new resource to be created. | `string` | `null` | no |
 | <a name="input_plan_per_site_scaling"></a> [plan\_per\_site\_scaling](#input\_plan\_per\_site\_scaling) | (Optional) Can Apps assigned to this App Service Plan be scaled independently? If set to false apps assigned to this plan will scale to all instances of the plan. Defaults to false. | `bool` | `false` | no |
-| <a name="input_plan_reserved"></a> [plan\_reserved](#input\_plan\_reserved) | (Optional) Is this App Service Plan Reserved. When creating a Linux App Service Plan, the reserved field must be set to true, and when creating a Windows/app App Service Plan the reserved field must be set to false. | `bool` | `null` | no |
-| <a name="input_plan_sku_size"></a> [plan\_sku\_size](#input\_plan\_sku\_size) | (Optional) Specifies the plan's instance size. | `string` | `null` | no |
-| <a name="input_plan_sku_tier"></a> [plan\_sku\_tier](#input\_plan\_sku\_tier) | (Optional) Specifies the plan's pricing tier. | `string` | `null` | no |
 | <a name="input_plan_type"></a> [plan\_type](#input\_plan\_type) | (Required) Specifies if app service plan is external or internal | `string` | `"internal"` | no |
+| <a name="input_python_version"></a> [python\_version](#input\_python\_version) | n/a | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the resource group in which to create the App Service and App Service Plan. | `string` | n/a | yes |
+| <a name="input_ruby_version"></a> [ruby\_version](#input\_ruby\_version) | n/a | `string` | `null` | no |
+| <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | (Required) The SKU for the plan. | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Optional) Subnet id wether you want to integrate the app service to a subnet. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
+| <a name="input_use_32_bit_worker_process"></a> [use\_32\_bit\_worker\_process](#input\_use\_32\_bit\_worker\_process) | (Optional) Should the Function App run in 32 bit mode, rather than 64 bit mode? Defaults to false. | `bool` | `false` | no |
 | <a name="input_vnet_integration"></a> [vnet\_integration](#input\_vnet\_integration) | (optional) enable vnet integration. Wheter it's true the subnet\_id should not be null. | `bool` | `false` | no |
 
 ## Outputs

--- a/app_service/main.tf
+++ b/app_service/main.tf
@@ -1,49 +1,63 @@
-resource "azurerm_app_service_plan" "this" {
-  count               = var.plan_type == "internal" ? 1 : 0
+locals {
+  allowed_ips     = [for ip in var.allowed_ips : { ip_address = ip, virtual_network_subnet_id = null }]
+  allowed_subnets = [for s in var.allowed_subnets : { ip_address = null, virtual_network_subnet_id = s }]
+  ip_restrictions = concat(local.allowed_subnets, local.allowed_ips)
+}
+
+resource "azurerm_service_plan" "this" {
+  count = var.plan_type == "internal" ? 1 : 0
+
   name                = var.plan_name
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  kind = var.plan_kind
-
-  sku {
-    tier = var.plan_sku_tier
-    size = var.plan_sku_size
-  }
+  sku_name = var.sku_name
+  os_type  = "Linux"
 
   maximum_elastic_worker_count = var.plan_maximum_elastic_worker_count
-  reserved                     = var.plan_reserved
-  per_site_scaling             = var.plan_per_site_scaling
+  per_site_scaling_enabled     = var.plan_per_site_scaling
 
   tags = var.tags
 }
 
-resource "azurerm_app_service" "this" {
+resource "azurerm_linux_web_app" "this" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  app_service_plan_id = var.plan_type == "internal" ? azurerm_app_service_plan.this[0].id : var.plan_id
-  https_only          = var.https_only
+  service_plan_id = var.plan_type == "internal" ? azurerm_service_plan.this[0].id : var.plan_id
+  https_only      = var.https_only
   #tfsec:ignore:azure-appservice-require-client-cert
-  client_cert_enabled     = var.client_cert_enabled
-  client_affinity_enabled = var.client_affinity_enabled
+  client_certificate_enabled = var.client_cert_enabled
+  client_affinity_enabled    = var.client_affinity_enabled
 
   app_settings = var.app_settings
 
   site_config {
-    always_on              = var.always_on
-    linux_fx_version       = var.linux_fx_version
+    always_on         = var.always_on
+    use_32_bit_worker = var.use_32_bit_worker_process
+    application_stack {
+      docker_image     = var.docker_image
+      docker_image_tag = var.docker_image_tag
+
+      dotnet_version      = var.dotnet_version
+      python_version      = var.python_version
+      go_version          = var.go_version
+      java_server         = var.java_server
+      java_server_version = var.java_server_version
+      java_version        = var.java_version
+      node_version        = var.node_version
+      php_version         = var.php_version
+      ruby_version        = var.ruby_version
+    }
     app_command_line       = var.app_command_line
-    min_tls_version        = "1.2"
+    minimum_tls_version    = "1.2"
     ftps_state             = var.ftps_state
     vnet_route_all_enabled = var.subnet_id == null ? false : true
 
     health_check_path = var.health_check_path != null ? var.health_check_path : null
 
-    php_version    = "7.4"
-    python_version = "3.4"
-    http2_enabled  = true
+    http2_enabled = true
 
     dynamic "ip_restriction" {
       for_each = var.allowed_subnets
@@ -57,12 +71,12 @@ resource "azurerm_app_service" "this" {
     }
 
     dynamic "ip_restriction" {
-      for_each = var.allowed_ips
+      for_each = local.ip_restrictions
       iterator = ip
 
       content {
-        ip_address                = ip.value
-        virtual_network_subnet_id = null
+        ip_address                = ip.value.ip_address
+        virtual_network_subnet_id = ip.value.virtual_network_subnet_id
         name                      = "rule"
       }
     }
@@ -83,8 +97,6 @@ resource "azurerm_app_service" "this" {
 
   lifecycle {
     ignore_changes = [
-      site_config.0.scm_type,
-      site_config.0.linux_fx_version, # deployments are made outside of Terraform
       app_settings["DOCKER_CUSTOM_IMAGE_NAME"]
     ]
   }
@@ -93,6 +105,6 @@ resource "azurerm_app_service" "this" {
 resource "azurerm_app_service_virtual_network_swift_connection" "app_service_virtual_network_swift_connection" {
   count = var.vnet_integration ? 1 : 0
 
-  app_service_id = azurerm_app_service.this.id
+  app_service_id = azurerm_linux_web_app.this.id
   subnet_id      = var.subnet_id
 }

--- a/app_service/outputs.tf
+++ b/app_service/outputs.tf
@@ -1,27 +1,27 @@
 output "id" {
-  value = azurerm_app_service.this.id
+  value = azurerm_linux_web_app.this.id
 }
 
 output "name" {
-  value = azurerm_app_service.this.name
+  value = azurerm_linux_web_app.this.name
 }
 
 output "plan_id" {
-  value = var.plan_type == "internal" ? azurerm_app_service_plan.this[0].id : var.plan_id
+  value = var.plan_type == "internal" ? azurerm_service_plan.this[0].id : var.plan_id
 }
 
 output "plan_name" {
-  value = var.plan_type == "internal" ? azurerm_app_service_plan.this[0].name : null
+  value = var.plan_type == "internal" ? azurerm_service_plan.this[0].name : null
 }
 
 output "default_site_hostname" {
-  value = azurerm_app_service.this.default_site_hostname
+  value = azurerm_linux_web_app.this.default_hostname
 }
 
 output "principal_id" {
-  value = azurerm_app_service.this.identity[0].principal_id
+  value = azurerm_linux_web_app.this.identity[0].principal_id
 }
 
 output "custom_domain_verification_id" {
-  value = azurerm_app_service.this.custom_domain_verification_id
+  value = azurerm_linux_web_app.this.custom_domain_verification_id
 }

--- a/app_service/tests/OLD/README.md
+++ b/app_service/tests/OLD/README.md
@@ -1,0 +1,9 @@
+# Test for Azure the app_service module
+
+Terraform template to test the Azure function_app module
+
+
+## How to use it
+- terraform init
+- terraform plan
+- terraform apply

--- a/app_service/tests/OLD/backend.ini
+++ b/app_service/tests/OLD/backend.ini
@@ -1,0 +1,1 @@
+subscription=DevOpsLab

--- a/app_service/tests/OLD/main.tf
+++ b/app_service/tests/OLD/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.30.0, <= 3.45.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "random_id" "unique" {
+  byte_length = 3
+}
+
+locals {
+  project = "${var.prefix}${random_id.unique.hex}"
+}

--- a/app_service/tests/OLD/output.tf
+++ b/app_service/tests/OLD/output.tf
@@ -1,0 +1,7 @@
+output "login_server" {
+  value = azurerm_container_registry.reg.login_server
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/app_service/tests/OLD/resources.tf
+++ b/app_service/tests/OLD/resources.tf
@@ -1,0 +1,135 @@
+resource "azurerm_container_registry" "reg" {
+  name                = "${local.project}registry"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "Premium"
+  admin_enabled       = false
+}
+
+resource "azurerm_application_insights" "ai" {
+  name                = "${local.project}-ai"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  application_type    = "other"
+
+  tags = var.tags
+}
+
+resource "random_id" "function_id" {
+  byte_length = 3
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.project}-rg"
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${local.project}-vnet"
+  address_space       = var.vnet_address_space
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  tags = var.tags
+}
+
+# Subnet to host the api config
+resource "azurerm_subnet" "arm_subnet" {
+  name                 = "${local.project}-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = var.subnet_cidr
+
+  delegation {
+    name = "${local.project}-delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_app_service_plan" "app_docker" {
+
+  name                = "${local.project}-plan-app-service-docker"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  kind = "Linux"
+
+  sku {
+    tier = "Basic"
+    size = "B1"
+  }
+  reserved = true
+
+  tags = var.tags
+}
+
+module "web_app_service_docker" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service?ref=v3.11.0"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+
+  plan_type = "external"
+  plan_id   = azurerm_app_service_plan.app_docker.id
+
+  # App service plan
+  name                = "${local.project}-app-service-docker"
+  client_cert_enabled = false
+  always_on           = false
+  linux_fx_version    = "DOCKER|${azurerm_container_registry.reg.login_server}/devopswebapppython:latest"
+  health_check_path   = "/status"
+
+  app_settings = {
+    # Monitoring
+    APPINSIGHTS_INSTRUMENTATIONKEY                  = azurerm_application_insights.ai.instrumentation_key
+    APPLICATIONINSIGHTS_CONNECTION_STRING           = "InstrumentationKey=${azurerm_application_insights.ai.instrumentation_key}"
+    APPINSIGHTS_PROFILERFEATURE_VERSION             = "1.0.0"
+    APPINSIGHTS_SNAPSHOTFEATURE_VERSION             = "1.0.0"
+    APPLICATIONINSIGHTS_CONFIGURATION_CONTENT       = ""
+    ApplicationInsightsAgent_EXTENSION_VERSION      = "~3"
+    DiagnosticServices_EXTENSION_VERSION            = "~3"
+    InstrumentationEngine_EXTENSION_VERSION         = "disabled"
+    SnapshotDebugger_EXTENSION_VERSION              = "disabled"
+    XDT_MicrosoftApplicationInsights_BaseExtensions = "disabled"
+    XDT_MicrosoftApplicationInsights_Mode           = "recommended"
+    XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
+    WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
+    TIMEOUT_DELAY                                   = 300
+    # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
+    WEBSITE_DNS_SERVER = "168.63.129.16"
+    # Spring Environment
+
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
+    WEBSITES_PORT                       = 8000
+    # DOCKER_REGISTRY_SERVER_URL      = "https://${module.acr[0].login_server}"
+    # DOCKER_REGISTRY_SERVER_USERNAME = module.acr[0].admin_username
+    # DOCKER_REGISTRY_SERVER_PASSWORD = module.acr[0].admin_password
+  }
+
+  allowed_ips = []
+
+  subnet_id = azurerm_subnet.arm_subnet.id
+
+  allowed_subnets = [
+    azurerm_subnet.arm_subnet.id,
+  ]
+
+  tags = var.tags
+}
+
+#
+# Role assignments
+#
+# resource "azurerm_role_assignment" "webapp_docker_to_acr" {
+#   count = var.is_web_app_service_docker_enabled ? 1 : 0
+
+#   scope                = data.azurerm_container_registry.acr.id
+#   role_definition_name = "AcrPull"
+#   principal_id         = module.web_app_service_docker[0].principal_id
+# }

--- a/app_service/tests/OLD/terraform.sh
+++ b/app_service/tests/OLD/terraform.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+shift 1
+other=$@
+
+subscription="MOCK_VALUE"
+
+case $action in
+    "init" | "apply" | "plan" | "destroy" )
+        # shellcheck source=/dev/null
+        if [ -e "./backend.ini" ]; then
+          source ./backend.ini
+        else
+          echo "Error: no backend.ini found!"
+          exit 1
+        fi
+
+        az account set -s "${subscription}"
+
+        terraform init
+        terraform "$action" $other
+        ;;
+    "clean" )
+        rm -rf .terraform* terraform.tfstate*
+        echo "cleaned..."
+        ;;
+    * )
+        echo "Missed action: init, apply, plan, destroy clean"
+        exit 1
+        ;;
+esac

--- a/app_service/tests/OLD/variables.tf
+++ b/app_service/tests/OLD/variables.tf
@@ -1,0 +1,31 @@
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+variable "prefix" {
+  description = "Resorce prefix"
+  type        = string
+  default     = "azrmtest"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "App_service example"
+  default = {
+    CreatedBy = "Terraform"
+    Source    = "https://github.com/pagopa/terraform-azurerm-v3"
+  }
+}
+
+### Custom variables
+
+variable "vnet_address_space" {
+  type    = list(string)
+  default = ["10.0.0.0/16"]
+}
+
+variable "subnet_cidr" {
+  type    = list(string)
+  default = ["10.0.1.0/26"]
+}

--- a/app_service/tests/README.md
+++ b/app_service/tests/README.md
@@ -1,0 +1,9 @@
+# Test for Azure the app_service module
+
+Terraform template to test the Azure function_app module
+
+
+## How to use it
+- terraform init
+- terraform plan
+- terraform apply

--- a/app_service/tests/backend.ini
+++ b/app_service/tests/backend.ini
@@ -1,0 +1,1 @@
+subscription=DevOpsLab

--- a/app_service/tests/main.tf
+++ b/app_service/tests/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.30.0, <= 3.45.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "random_id" "unique" {
+  byte_length = 3
+}
+
+locals {
+  project = "${var.prefix}${random_id.unique.hex}"
+}

--- a/app_service/tests/migrate.sh
+++ b/app_service/tests/migrate.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -e
+############################################################
+# Remove and import a Terraform resource from the tfstate
+############################################################
+# Global variables
+VERS="1.0"
+
+############################################################
+# Print usage information                                                     #
+############################################################
+function print_usage() {
+  me=`basename "$0"`
+  echo "Setup v."${VERS} "sets up a configuration relative to a specific subscription"
+  echo "  ./${me} <resource name to remove> <resource name to add> <ENV>"
+  for thisenv in $(ls "env/")
+  do
+      echo "  Example: ./${me} \"module.function_lollipop[0].azurerm_function_app.this\" \"module.function_lollipop[0].azurerm_linux_function_app.this\" ${thisenv}"
+  done
+  echo
+  echo "Syntax: setup.sh [-l|h]"
+  echo "  options:"
+  echo "  h     Print this Help."
+  echo "  l     List available environments."
+  echo
+}
+
+function removeAndImport() {
+    local old_resource_name="$1"
+    # Square brackets are not processed normally by grep, otherwise
+    esc_old_resource_name=$(echo "$old_resource_name" | sed 's/\[/\\[/g; s/\]/\\]/g')
+
+    local new_resource_name="$2"
+
+    # Check if the "Terraform" and "jq" commands are available
+    if ! which terraform &> /dev/null && which jq &> /dev/null; then
+        echo "Please install terraform and jq before proceeding."
+        exit 1
+    fi
+
+    if [ -z "$old_resource_name" ] || [ -z "$new_resource_name" ] ; then
+        echo "You need to define the resources to be removed and imported in order to proceed and the environment to be used!!"
+        exit 1
+    fi
+    if [ "$(terraform show | grep $esc_old_resource_name)" ]; then
+        # Look for the resource ID in the child_module
+        resource_id=$(terraform show -json | jq --arg resource "$old_resource_name" '.values.root_module.child_modules[].resources[] | select(.address==$resource).values.id' | tr -d '"')
+        if [ -z "$resource_id"]; then
+            # Otherwise it search for it in the root_module
+            resource_id=$(terraform show -json | jq --arg resource "$old_resource_name" '.values.root_module.resources[] | select(.address==$resource).values.id' | tr -d '"')
+        fi        
+        echo "resource_id: ${resource_id}"
+        # Import the resource
+        echo "Importing the resource ${new_resource_name}"
+        echo "$new_resource_name $resource_id"
+        terraform import $new_resource_name $resource_id 
+        if [ $? -eq 0 ]; then
+            echo "Successfully imported the resource ${new_resource_name} with ID: ${resource_id}!"
+            # Remove the resource from the state file
+            echo "Removing the resource ${old_resource_name}"
+            terraform state rm "$old_resource_name"
+            if [ $? -eq 0 ]; then
+                echo "$old_resource_name removed!"
+            else
+                echo "I can't remove the resource $old_resource_name from your Terraform state!"
+            fi
+        else
+            echo "I can't import the resource $new_resource_name"
+        fi
+    else
+        echo "I can't find the resource $old_resource_name in your Terraform state"
+    fi
+}
+
+############################################################
+# Main program                                             #
+############################################################
+# Get the options
+while getopts ":hl-:" option; do
+   case $option in
+      h) # display Help
+         print_usage
+         exit;;
+      l) # list available environments
+         echo "Available environment(-s):"
+         ls -1 "env/"
+         exit;;
+      *) # Invalid option
+         echo "Error: Invalid option"
+         exit;;
+   esac
+done
+
+if [[ $2 ]]; then
+  removeAndImport $1 $2
+
+else
+  print_usage
+fi
+exit 0
+
+

--- a/app_service/tests/output.tf
+++ b/app_service/tests/output.tf
@@ -1,0 +1,7 @@
+output "login_server" {
+  value = azurerm_container_registry.reg.login_server
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/app_service/tests/resources.tf
+++ b/app_service/tests/resources.tf
@@ -1,0 +1,130 @@
+resource "azurerm_container_registry" "reg" {
+  name                = "${local.project}registry"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "Premium"
+  admin_enabled       = false
+}
+
+resource "azurerm_application_insights" "ai" {
+  name                = "${local.project}-ai"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  application_type    = "other"
+
+  tags = var.tags
+}
+
+resource "random_id" "function_id" {
+  byte_length = 3
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.project}-rg"
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${local.project}-vnet"
+  address_space       = var.vnet_address_space
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  tags = var.tags
+}
+
+# Subnet to host the api config
+resource "azurerm_subnet" "arm_subnet" {
+  name                 = "${local.project}-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = var.subnet_cidr
+
+  delegation {
+    name = "${local.project}-delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_service_plan" "app_docker" {
+
+  name                = "${local.project}-plan-app-service-docker"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  os_type  = "Linux"
+  sku_name = "P1v2"
+
+  tags = var.tags
+}
+
+module "web_app_service_docker" {
+  source = "../"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+
+  plan_type = "external"
+  plan_id   = azurerm_service_plan.app_docker.id
+
+  # App service plan
+  name                = "${local.project}-app-service-docker"
+  client_cert_enabled = false
+  always_on           = false
+  docker_image        = "${azurerm_container_registry.reg.login_server}/devopswebapppython"
+  docker_image_tag    = "latest"
+
+  health_check_path = "/status"
+  sku_name          = "P1v2"
+
+  app_settings = {
+    # Monitoring
+    APPINSIGHTS_INSTRUMENTATIONKEY                  = azurerm_application_insights.ai.instrumentation_key
+    APPLICATIONINSIGHTS_CONNECTION_STRING           = "InstrumentationKey=${azurerm_application_insights.ai.instrumentation_key}"
+    APPINSIGHTS_PROFILERFEATURE_VERSION             = "1.0.0"
+    APPINSIGHTS_SNAPSHOTFEATURE_VERSION             = "1.0.0"
+    APPLICATIONINSIGHTS_CONFIGURATION_CONTENT       = ""
+    ApplicationInsightsAgent_EXTENSION_VERSION      = "~3"
+    DiagnosticServices_EXTENSION_VERSION            = "~3"
+    InstrumentationEngine_EXTENSION_VERSION         = "disabled"
+    SnapshotDebugger_EXTENSION_VERSION              = "disabled"
+    XDT_MicrosoftApplicationInsights_BaseExtensions = "disabled"
+    XDT_MicrosoftApplicationInsights_Mode           = "recommended"
+    XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
+    WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
+    TIMEOUT_DELAY                                   = 300
+    # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
+    WEBSITE_DNS_SERVER = "168.63.129.16"
+    # Spring Environment
+
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
+    WEBSITES_PORT                       = 8000
+  }
+
+  allowed_ips = []
+
+  subnet_id = azurerm_subnet.arm_subnet.id
+
+  allowed_subnets = [
+    azurerm_subnet.arm_subnet.id,
+  ]
+
+  tags = var.tags
+}
+
+#
+# Role assignments
+#
+# resource "azurerm_role_assignment" "webapp_docker_to_acr" {
+#   count = var.is_web_app_service_docker_enabled ? 1 : 0
+
+#   scope                = data.azurerm_container_registry.acr.id
+#   role_definition_name = "AcrPull"
+#   principal_id         = module.web_app_service_docker[0].principal_id
+# }

--- a/app_service/tests/terraform.sh
+++ b/app_service/tests/terraform.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+shift 1
+other=$@
+
+subscription="MOCK_VALUE"
+
+case $action in
+    "init" | "apply" | "plan" | "destroy" )
+        # shellcheck source=/dev/null
+        if [ -e "./backend.ini" ]; then
+          source ./backend.ini
+        else
+          echo "Error: no backend.ini found!"
+          exit 1
+        fi
+
+        az account set -s "${subscription}"
+
+        terraform init
+        terraform "$action" $other
+        ;;
+    "clean" )
+        rm -rf .terraform* terraform.tfstate*
+        echo "cleaned..."
+        ;;
+    * )
+        echo "Missed action: init, apply, plan, destroy clean"
+        exit 1
+        ;;
+esac

--- a/app_service/tests/variables.tf
+++ b/app_service/tests/variables.tf
@@ -1,0 +1,31 @@
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+variable "prefix" {
+  description = "Resorce prefix"
+  type        = string
+  default     = "azrmtest"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "App_service example"
+  default = {
+    CreatedBy = "Terraform"
+    Source    = "https://github.com/pagopa/terraform-azurerm-v3"
+  }
+}
+
+### Custom variables
+
+variable "vnet_address_space" {
+  type    = list(string)
+  default = ["10.0.0.0/16"]
+}
+
+variable "subnet_cidr" {
+  type    = list(string)
+  default = ["10.0.1.0/26"]
+}

--- a/app_service/variables.tf
+++ b/app_service/variables.tf
@@ -48,6 +48,12 @@ variable "sku_name" {
   default     = null
 }
 
+variable "sticky_settings" {
+  type        = list(string)
+  description = "(Optional) A list of app_setting names that the Linux Function App will not swap between Slots when a swap operation is triggered"
+  default     = []
+}
+
 variable "plan_maximum_elastic_worker_count" {
   type        = number
   description = "(Optional) The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan."

--- a/app_service/variables.tf
+++ b/app_service/variables.tf
@@ -42,27 +42,15 @@ variable "plan_kind" {
   default     = null
 }
 
-variable "plan_sku_tier" {
+variable "sku_name" {
   type        = string
-  description = "(Optional) Specifies the plan's pricing tier."
-  default     = null
-}
-
-variable "plan_sku_size" {
-  type        = string
-  description = "(Optional) Specifies the plan's instance size."
+  description = "(Required) The SKU for the plan."
   default     = null
 }
 
 variable "plan_maximum_elastic_worker_count" {
   type        = number
   description = "(Optional) The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan."
-  default     = null
-}
-
-variable "plan_reserved" {
-  type        = bool
-  description = "(Optional) Is this App Service Plan Reserved. When creating a Linux App Service Plan, the reserved field must be set to true, and when creating a Windows/app App Service Plan the reserved field must be set to false."
   default     = null
 }
 
@@ -83,6 +71,12 @@ variable "https_only" {
   type        = bool
   description = "(Optional) Can the App Service only be accessed via HTTPS? Defaults to true."
   default     = true
+}
+
+variable "use_32_bit_worker_process" {
+  type        = bool
+  description = "(Optional) Should the Function App run in 32 bit mode, rather than 64 bit mode? Defaults to false."
+  default     = false
 }
 
 variable "client_affinity_enabled" {
@@ -106,13 +100,6 @@ variable "always_on" {
   type        = bool
   description = "(Optional) Should the app be loaded at all times? Defaults to false."
   default     = false
-}
-
-# Ex. for linux "NODE|10-lts"
-variable "linux_fx_version" {
-  type        = string
-  description = "(Optional) Linux App Framework and version for the App Service."
-  default     = null
 }
 
 variable "app_command_line" {
@@ -159,4 +146,50 @@ variable "subnet_id" {
 
 variable "tags" {
   type = map(any)
+}
+
+# Framework choice
+variable "docker_image" {
+  type    = string
+  default = null
+}
+variable "docker_image_tag" {
+  type    = string
+  default = null
+}
+variable "dotnet_version" {
+  type    = string
+  default = null
+}
+variable "go_version" {
+  type    = string
+  default = null
+}
+variable "java_server" {
+  type    = string
+  default = null
+}
+variable "java_server_version" {
+  type    = string
+  default = null
+}
+variable "java_version" {
+  type    = string
+  default = null
+}
+variable "node_version" {
+  type    = string
+  default = null
+}
+variable "php_version" {
+  type    = string
+  default = null
+}
+variable "python_version" {
+  type    = string
+  default = null
+}
+variable "ruby_version" {
+  type    = string
+  default = null
 }

--- a/app_service/versions.tf
+++ b/app_service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.30.0, <= 3.45.0"
+      version = ">= 3.39.0, <= 3.45.0"
     }
   }
 }

--- a/app_service_slot/README.md
+++ b/app_service_slot/README.md
@@ -1,6 +1,53 @@
 # App service slot
 
-This module allow the creation of app service slots
+This module allow the creation of app service slots.
+In terraform output you can get the the slot's name and id.
+
+## How to use it
+Use the example Terraform template, saved in `./tests`, to test this module  and get some advices.
+
+## How to migrate from `azurerm_app_service_slot` to `azurerm_linux_web_app_slot`
+The script tests/migrate.sh will remove and import the deprecated resources as new ones.
+You need to know the resource old and new names.
+```
+e.g.
+# app_service resources to migrate
+cd tests
+./migrate.sh module.web_app_service_docker.azurerm_app_service.this module.web_app_service_docker.azurerm_linux_web_app.this
+./migrate.sh azurerm_app_service_plan.app_docker azurerm_service_plan.app_docker
+
+# app_service_slot resource to migrate
+./migrate.sh module.web_app_service_slot_docker.azurerm_app_service_slot.this module.web_app_service_slot_docker.azurerm_linux_web_app_slot.this
+```
+
+## Note about migrating from `azurerm_app_service_slot` to `azurerm_linux_web_app_slot`
+
+Since the resource `azurerm_app_service_slot` has been deprecated in version 3.0 of the AzureRM provider, the newer `azurerm_linux_web_app_slot` resource is used in this module, thus the following variables have been:
+
+removed:
+- os_type
+- app_service_plan_info/sku_tier
+- linux_fx_version
+- app_service_plan_id
+
+replaced:
+- min_tls_version -> minimum_tls_version
+- client_cert_enabled -> client_certificate_enabled
+
+## How to configure the Linux framework
+
+Don't use `linux_fx_version` anymore.
+Now you need to specify **only** one variable of the following list:
+- docker - (Optional) One or more docker blocks as defined below.
+- dotnet_version - (Optional) The version of .NET to use. Possible values include 3.1, 6.0 and 7.0.
+- use_dotnet_isolated_runtime - (Optional) Should the DotNet process use an isolated runtime. Defaults to false.
+- java_version - (Optional) The Version of Java to use. Supported versions include 8, 11 & 17 (In-Preview).
+- node_version - (Optional) The version of Node to run. Possible values include 12, 14, 16 and 18.
+- python_version - (Optional) The version of Python to run. Possible values are 3.10, 3.9, 3.8 and 3.7.
+- powershell_core_version - (Optional) The version of PowerShell Core to run. Possible values are 7, and 7.2.
+- use_custom_runtime - (Optional) Should the Linux Function App use a custom runtime?
+
+Of course, the values listed above may change in the future, so please check which ones are still valid.
 
 <!-- markdownlint-disable -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -15,7 +62,7 @@ This module allow the creation of app service slots
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.30.0, <= 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
 
 ## Modules
 

--- a/app_service_slot/README.md
+++ b/app_service_slot/README.md
@@ -85,7 +85,6 @@ No modules.
 | <a name="input_app_command_line"></a> [app\_command\_line](#input\_app\_command\_line) | (Optional) App command line to launch, e.g. /sbin/myserver -b 0.0.0.0. | `string` | `null` | no |
 | <a name="input_app_service_id"></a> [app\_service\_id](#input\_app\_service\_id) | (Required) The id of the App Service within which to create the App Service Slot. | `string` | n/a | yes |
 | <a name="input_app_service_name"></a> [app\_service\_name](#input\_app\_service\_name) | (Required) The name of the App Service within which to create the App Service Slot. Changing this forces a new resource to be created. | `string` | n/a | yes |
-| <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | (Required) The ID of the App Service Plan within which to create this App Service Slot. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | n/a | `map(string)` | `{}` | no |
 | <a name="input_client_affinity_enabled"></a> [client\_affinity\_enabled](#input\_client\_affinity\_enabled) | (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance? Defaults to false. | `bool` | `false` | no |
 | <a name="input_client_certificate_enabled"></a> [client\_certificate\_enabled](#input\_client\_certificate\_enabled) | Should the function app use Client Certificates | `bool` | `false` | no |

--- a/app_service_slot/README.md
+++ b/app_service_slot/README.md
@@ -15,7 +15,7 @@ This module allow the creation of app service slots
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.30.0, <= 3.45.0 |
 
 ## Modules
 
@@ -25,8 +25,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_app_service_slot.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_slot) | resource |
 | [azurerm_app_service_slot_virtual_network_swift_connection.app_service_virtual_network_swift_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_slot_virtual_network_swift_connection) | resource |
+| [azurerm_linux_web_app_slot.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app_slot) | resource |
 
 ## Inputs
 
@@ -41,15 +41,27 @@ No modules.
 | <a name="input_app_service_plan_id"></a> [app\_service\_plan\_id](#input\_app\_service\_plan\_id) | (Required) The ID of the App Service Plan within which to create this App Service Slot. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_app_settings"></a> [app\_settings](#input\_app\_settings) | n/a | `map(string)` | `{}` | no |
 | <a name="input_client_affinity_enabled"></a> [client\_affinity\_enabled](#input\_client\_affinity\_enabled) | (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance? Defaults to false. | `bool` | `false` | no |
+| <a name="input_client_certificate_enabled"></a> [client\_certificate\_enabled](#input\_client\_certificate\_enabled) | Should the function app use Client Certificates | `bool` | `false` | no |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Framework choice | `string` | `null` | no |
+| <a name="input_docker_image_tag"></a> [docker\_image\_tag](#input\_docker\_image\_tag) | n/a | `string` | `null` | no |
+| <a name="input_dotnet_version"></a> [dotnet\_version](#input\_dotnet\_version) | n/a | `string` | `null` | no |
 | <a name="input_ftps_state"></a> [ftps\_state](#input\_ftps\_state) | (Optional) Enable FTPS connection ( Default: Disabled ) | `string` | `"Disabled"` | no |
+| <a name="input_go_version"></a> [go\_version](#input\_go\_version) | n/a | `string` | `null` | no |
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | (Optional) The health check path to be pinged by App Service. | `string` | `null` | no |
 | <a name="input_https_only"></a> [https\_only](#input\_https\_only) | (Optional) Can the App Service only be accessed via HTTPS? Defaults to true. | `bool` | `true` | no |
-| <a name="input_linux_fx_version"></a> [linux\_fx\_version](#input\_linux\_fx\_version) | (Optional) Linux App Framework and version for the App Service. | `string` | `null` | no |
+| <a name="input_java_server"></a> [java\_server](#input\_java\_server) | n/a | `string` | `null` | no |
+| <a name="input_java_server_version"></a> [java\_server\_version](#input\_java\_server\_version) | n/a | `string` | `null` | no |
+| <a name="input_java_version"></a> [java\_version](#input\_java\_version) | n/a | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | `"westeurope"` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) Specifies the name of the App Service. Changing this forces a new resource to be created. | `string` | n/a | yes |
+| <a name="input_node_version"></a> [node\_version](#input\_node\_version) | n/a | `string` | `null` | no |
+| <a name="input_php_version"></a> [php\_version](#input\_php\_version) | n/a | `string` | `null` | no |
+| <a name="input_python_version"></a> [python\_version](#input\_python\_version) | n/a | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the resource group in which to create the App Service and App Service Plan. | `string` | n/a | yes |
+| <a name="input_ruby_version"></a> [ruby\_version](#input\_ruby\_version) | n/a | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Optional) Subnet id wether you want to integrate the app service to a subnet. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
+| <a name="input_use_32_bit_worker_process"></a> [use\_32\_bit\_worker\_process](#input\_use\_32\_bit\_worker\_process) | (Optional) Should the App Service Slot run in 32 bit mode, rather than 64 bit mode? Defaults to false. | `bool` | `false` | no |
 | <a name="input_vnet_integration"></a> [vnet\_integration](#input\_vnet\_integration) | (optional) enable vnet integration. Wheter it's true the subnet\_id should not be null. | `bool` | `false` | no |
 
 ## Outputs

--- a/app_service_slot/README.md
+++ b/app_service_slot/README.md
@@ -56,7 +56,7 @@ Of course, the values listed above may change in the future, so please check whi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.30.0, <= 3.45.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.39.0, <= 3.45.0 |
 
 ## Providers
 

--- a/app_service_slot/main.tf
+++ b/app_service_slot/main.tf
@@ -6,7 +6,16 @@ resource "azurerm_linux_web_app_slot" "this" {
   client_affinity_enabled    = var.client_affinity_enabled
   client_certificate_enabled = var.client_certificate_enabled
 
-  app_settings = var.app_settings
+  # https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  app_settings = merge(
+    {
+      # https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+      WEBSITE_DNS_SERVER = "168.63.129.16"
+      # https://docs.microsoft.com/en-us/azure/azure-monitor/app/sampling
+      APPINSIGHTS_SAMPLING_PERCENTAGE = 5
+    },
+    var.app_settings,
+  )
 
   site_config {
     always_on         = var.always_on
@@ -65,7 +74,9 @@ resource "azurerm_linux_web_app_slot" "this" {
 
   lifecycle {
     ignore_changes = [
-      app_settings["DOCKER_CUSTOM_IMAGE_NAME"]
+      app_settings["DOCKER_CUSTOM_IMAGE_NAME"],
+      virtual_network_subnet_id,
+      app_settings["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"],
     ]
   }
 }

--- a/app_service_slot/main.tf
+++ b/app_service_slot/main.tf
@@ -1,28 +1,38 @@
-resource "azurerm_app_service_slot" "this" {
-  name                = var.name
-  location            = var.location
-  resource_group_name = var.resource_group_name
+resource "azurerm_linux_web_app_slot" "this" {
+  name = var.name
 
-  app_service_plan_id     = var.app_service_plan_id
-  app_service_name        = var.app_service_name
-  https_only              = var.https_only
-  client_affinity_enabled = var.client_affinity_enabled
+  app_service_id             = var.app_service_id
+  https_only                 = var.https_only
+  client_affinity_enabled    = var.client_affinity_enabled
+  client_certificate_enabled = var.client_certificate_enabled
 
   app_settings = var.app_settings
 
   site_config {
-    always_on              = var.always_on
-    linux_fx_version       = var.linux_fx_version
+    always_on         = var.always_on
+    use_32_bit_worker = var.use_32_bit_worker_process
+    application_stack {
+      docker_image     = var.docker_image
+      docker_image_tag = var.docker_image_tag
+
+      dotnet_version      = var.dotnet_version
+      python_version      = var.python_version
+      go_version          = var.go_version
+      java_server         = var.java_server
+      java_server_version = var.java_server_version
+      java_version        = var.java_version
+      node_version        = var.node_version
+      php_version         = var.php_version
+      ruby_version        = var.ruby_version
+    }
     app_command_line       = var.app_command_line
-    min_tls_version        = "1.2"
+    minimum_tls_version    = "1.2"
     ftps_state             = var.ftps_state
     vnet_route_all_enabled = var.subnet_id == null ? false : true
 
     health_check_path = var.health_check_path != null ? var.health_check_path : null
 
-    php_version    = "7.4"
-    python_version = "3.4"
-    http2_enabled  = true
+    http2_enabled = true
 
     dynamic "ip_restriction" {
       for_each = var.allowed_subnets
@@ -55,8 +65,6 @@ resource "azurerm_app_service_slot" "this" {
 
   lifecycle {
     ignore_changes = [
-      site_config.0.scm_type,
-      site_config.0.linux_fx_version, # deployments are made outside of Terraform
       app_settings["DOCKER_CUSTOM_IMAGE_NAME"]
     ]
   }
@@ -65,7 +73,7 @@ resource "azurerm_app_service_slot" "this" {
 resource "azurerm_app_service_slot_virtual_network_swift_connection" "app_service_virtual_network_swift_connection" {
   count = var.vnet_integration ? 1 : 0
 
-  slot_name      = azurerm_app_service_slot.this.name
+  slot_name      = azurerm_linux_web_app_slot.this.name
   app_service_id = var.app_service_id
   subnet_id      = var.subnet_id
 }

--- a/app_service_slot/outputs.tf
+++ b/app_service_slot/outputs.tf
@@ -1,15 +1,15 @@
 output "id" {
-  value = azurerm_app_service_slot.this.id
+  value = azurerm_linux_web_app_slot.this.id
 }
 
 output "name" {
-  value = azurerm_app_service_slot.this.name
+  value = azurerm_linux_web_app_slot.this.name
 }
 
 output "default_site_hostname" {
-  value = azurerm_app_service_slot.this.default_site_hostname
+  value = azurerm_linux_web_app_slot.this.default_hostname
 }
 
 output "principal_id" {
-  value = azurerm_app_service_slot.this.identity[0].principal_id
+  value = azurerm_linux_web_app_slot.this.identity[0].principal_id
 }

--- a/app_service_slot/tests/OLD/README.md
+++ b/app_service_slot/tests/OLD/README.md
@@ -1,0 +1,9 @@
+# Test for Azure the app_service module
+
+Terraform template to test the Azure function_app module
+
+
+## How to use it
+- terraform init
+- terraform plan
+- terraform apply

--- a/app_service_slot/tests/OLD/backend.ini
+++ b/app_service_slot/tests/OLD/backend.ini
@@ -1,0 +1,1 @@
+subscription=DevOpsLab

--- a/app_service_slot/tests/OLD/main.tf
+++ b/app_service_slot/tests/OLD/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.30.0, <= 3.45.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "random_id" "unique" {
+  byte_length = 3
+}
+
+locals {
+  project = "${var.prefix}${random_id.unique.hex}"
+}

--- a/app_service_slot/tests/OLD/output.tf
+++ b/app_service_slot/tests/OLD/output.tf
@@ -1,0 +1,7 @@
+output "login_server" {
+  value = azurerm_container_registry.reg.login_server
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/app_service_slot/tests/OLD/resources.tf
+++ b/app_service_slot/tests/OLD/resources.tf
@@ -1,0 +1,154 @@
+locals {
+  app_settings = {
+    # Monitoring
+    APPINSIGHTS_INSTRUMENTATIONKEY                  = azurerm_application_insights.ai.instrumentation_key
+    APPLICATIONINSIGHTS_CONNECTION_STRING           = "InstrumentationKey=${azurerm_application_insights.ai.instrumentation_key}"
+    APPINSIGHTS_PROFILERFEATURE_VERSION             = "1.0.0"
+    APPINSIGHTS_SNAPSHOTFEATURE_VERSION             = "1.0.0"
+    APPLICATIONINSIGHTS_CONFIGURATION_CONTENT       = ""
+    ApplicationInsightsAgent_EXTENSION_VERSION      = "~3"
+    DiagnosticServices_EXTENSION_VERSION            = "~3"
+    InstrumentationEngine_EXTENSION_VERSION         = "disabled"
+    SnapshotDebugger_EXTENSION_VERSION              = "disabled"
+    XDT_MicrosoftApplicationInsights_BaseExtensions = "disabled"
+    XDT_MicrosoftApplicationInsights_Mode           = "recommended"
+    XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
+    WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
+    TIMEOUT_DELAY                                   = 300
+    # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
+    WEBSITE_DNS_SERVER = "168.63.129.16"
+    # Spring Environment
+
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
+    WEBSITES_PORT                       = 8000
+  }
+}
+
+resource "random_id" "function_id" {
+  byte_length = 3
+}
+
+resource "azurerm_container_registry" "reg" {
+  name                = "${local.project}registry"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "Premium"
+  admin_enabled       = false
+}
+
+resource "azurerm_application_insights" "ai" {
+  name                = "${local.project}-ai"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  application_type    = "other"
+
+  tags = var.tags
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.project}-rg"
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${local.project}-vnet"
+  address_space       = var.vnet_address_space
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  tags = var.tags
+}
+
+# Subnet to host the api config
+resource "azurerm_subnet" "arm_subnet" {
+  name                 = "${local.project}-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = var.subnet_cidr
+
+  delegation {
+    name = "${local.project}-delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_app_service_plan" "app_docker" {
+
+  name                = "${local.project}-plan-app-service-docker"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  kind = "Linux"
+
+  sku {
+    tier = "P1v3"
+    size = "P1v3"
+  }
+  reserved = true
+
+  tags = var.tags
+}
+
+module "web_app_service_docker" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service?ref=v3.11.0"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+
+  plan_type = "external"
+  plan_id   = azurerm_app_service_plan.app_docker.id
+
+  # App service plan
+  name                = "${local.project}-app-service-docker"
+  client_cert_enabled = false
+  always_on           = false
+  linux_fx_version    = "DOCKER|${azurerm_container_registry.reg.login_server}/devopswebapppython:latest"
+  health_check_path   = "/status"
+
+  app_settings = local.app_settings
+
+  allowed_ips = []
+
+  subnet_id = azurerm_subnet.arm_subnet.id
+
+  allowed_subnets = [
+    azurerm_subnet.arm_subnet.id,
+  ]
+
+  tags = var.tags
+}
+
+module "web_app_service_slot_docker" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_service_slot?ref=v2.2.0"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+
+  app_service_plan_id = module.web_app_service_docker.plan_id
+  app_service_name    = module.web_app_service_docker.name
+  app_service_id      = module.web_app_service_docker.id
+
+  # App service plan
+  name              = "${local.project}-app-service-slot-docker"
+  always_on         = false
+  linux_fx_version  = format("DOCKER|${azurerm_container_registry.reg.login_server}/devopswebapppython:latest")
+  health_check_path = "/status"
+
+  app_settings = local.app_settings
+
+  subnet_id = azurerm_subnet.arm_subnet.id
+
+  allowed_ips = []
+
+  allowed_subnets = [
+    azurerm_subnet.arm_subnet.id,
+  ]
+
+  tags = var.tags
+}

--- a/app_service_slot/tests/OLD/resources.tf
+++ b/app_service_slot/tests/OLD/resources.tf
@@ -15,8 +15,6 @@ locals {
     XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
     WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
     TIMEOUT_DELAY                                   = 300
-    # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
-    WEBSITE_DNS_SERVER = "168.63.129.16"
     # Spring Environment
 
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false

--- a/app_service_slot/tests/OLD/terraform.sh
+++ b/app_service_slot/tests/OLD/terraform.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+shift 1
+other=$@
+
+subscription="MOCK_VALUE"
+
+case $action in
+    "init" | "apply" | "plan" | "destroy" )
+        # shellcheck source=/dev/null
+        if [ -e "./backend.ini" ]; then
+          source ./backend.ini
+        else
+          echo "Error: no backend.ini found!"
+          exit 1
+        fi
+
+        az account set -s "${subscription}"
+
+        terraform init
+        terraform "$action" $other
+        ;;
+    "clean" )
+        rm -rf .terraform* terraform.tfstate*
+        echo "cleaned..."
+        ;;
+    * )
+        echo "Missed action: init, apply, plan, destroy clean"
+        exit 1
+        ;;
+esac

--- a/app_service_slot/tests/OLD/variables.tf
+++ b/app_service_slot/tests/OLD/variables.tf
@@ -1,0 +1,31 @@
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+variable "prefix" {
+  description = "Resorce prefix"
+  type        = string
+  default     = "azrmtest"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "App_service example"
+  default = {
+    CreatedBy = "Terraform"
+    Source    = "https://github.com/pagopa/terraform-azurerm-v3"
+  }
+}
+
+### Custom variables
+
+variable "vnet_address_space" {
+  type    = list(string)
+  default = ["10.0.0.0/16"]
+}
+
+variable "subnet_cidr" {
+  type    = list(string)
+  default = ["10.0.1.0/26"]
+}

--- a/app_service_slot/tests/README.md
+++ b/app_service_slot/tests/README.md
@@ -1,0 +1,9 @@
+# Test for Azure the app_service module
+
+Terraform template to test the Azure function_app module
+
+
+## How to use it
+- terraform init
+- terraform plan
+- terraform apply

--- a/app_service_slot/tests/backend.ini
+++ b/app_service_slot/tests/backend.ini
@@ -1,0 +1,1 @@
+subscription=DevOpsLab

--- a/app_service_slot/tests/main.tf
+++ b/app_service_slot/tests/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.30.0, <= 3.45.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "random_id" "unique" {
+  byte_length = 3
+}
+
+locals {
+  project = "${var.prefix}${random_id.unique.hex}"
+}

--- a/app_service_slot/tests/migrate.sh
+++ b/app_service_slot/tests/migrate.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -e
+############################################################
+# Remove and import a Terraform resource from the tfstate
+############################################################
+# Global variables
+VERS="1.0"
+
+############################################################
+# Print usage information                                                     #
+############################################################
+function print_usage() {
+  me=`basename "$0"`
+  echo "Setup v."${VERS} "sets up a configuration relative to a specific subscription"
+  echo "  ./${me} <resource name to remove> <resource name to add> <ENV>"
+  for thisenv in $(ls "env/")
+  do
+      echo "  Example: ./${me} \"module.function_lollipop[0].azurerm_function_app.this\" \"module.function_lollipop[0].azurerm_linux_function_app.this\" ${thisenv}"
+  done
+  echo
+  echo "Syntax: setup.sh [-l|h]"
+  echo "  options:"
+  echo "  h     Print this Help."
+  echo "  l     List available environments."
+  echo
+}
+
+function removeAndImport() {
+    local old_resource_name="$1"
+    # Square brackets are not processed normally by grep, otherwise
+    esc_old_resource_name=$(echo "$old_resource_name" | sed 's/\[/\\[/g; s/\]/\\]/g')
+
+    local new_resource_name="$2"
+
+    # Check if the "Terraform" and "jq" commands are available
+    if ! which terraform &> /dev/null && which jq &> /dev/null; then
+        echo "Please install terraform and jq before proceeding."
+        exit 1
+    fi
+
+    if [ -z "$old_resource_name" ] || [ -z "$new_resource_name" ] ; then
+        echo "You need to define the resources to be removed and imported in order to proceed and the environment to be used!!"
+        exit 1
+    fi
+    if [ "$(terraform show | grep $esc_old_resource_name)" ]; then
+        # Look for the resource ID in the child_module
+        resource_id=$(terraform show -json | jq --arg resource "$old_resource_name" '.values.root_module.child_modules[].resources[] | select(.address==$resource).values.id' | tr -d '"')
+        if [ -z "$resource_id" ]; then
+            # Otherwise it search for it in the root_module
+            resource_id=$(terraform show -json | jq --arg resource "$old_resource_name" '.values.root_module.resources[] | select(.address==$resource).values.id' | tr -d '"')
+        fi        
+        echo "resource_id: ${resource_id}"
+        # Import the resource
+        echo "Importing the resource ${new_resource_name}"
+        echo "$new_resource_name $resource_id"
+        terraform import $new_resource_name $resource_id 
+        if [ $? -eq 0 ]; then
+            echo "Successfully imported the resource ${new_resource_name} with ID: ${resource_id}!"
+            # Remove the resource from the state file
+            echo "Removing the resource ${old_resource_name}"
+            terraform state rm "$old_resource_name"
+            if [ $? -eq 0 ]; then
+                echo "$old_resource_name removed!"
+            else
+                echo "I can't remove the resource $old_resource_name from your Terraform state!"
+            fi
+        else
+            echo "I can't import the resource $new_resource_name"
+        fi
+    else
+        echo "I can't find the resource $old_resource_name in your Terraform state"
+    fi
+}
+
+############################################################
+# Main program                                             #
+############################################################
+# Get the options
+while getopts ":hl-:" option; do
+   case $option in
+      h) # display Help
+         print_usage
+         exit;;
+      l) # list available environments
+         echo "Available environment(-s):"
+         ls -1 "env/"
+         exit;;
+      *) # Invalid option
+         echo "Error: Invalid option"
+         exit;;
+   esac
+done
+
+if [[ $2 ]]; then
+  removeAndImport $1 $2
+
+else
+  print_usage
+fi
+exit 0
+
+

--- a/app_service_slot/tests/output.tf
+++ b/app_service_slot/tests/output.tf
@@ -1,0 +1,7 @@
+output "login_server" {
+  value = azurerm_container_registry.reg.login_server
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/app_service_slot/tests/resources.tf
+++ b/app_service_slot/tests/resources.tf
@@ -15,8 +15,6 @@ locals {
     XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
     WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
     TIMEOUT_DELAY                                   = 300
-    # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
-    WEBSITE_DNS_SERVER = "168.63.129.16"
     # Spring Environment
 
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false

--- a/app_service_slot/tests/resources.tf
+++ b/app_service_slot/tests/resources.tf
@@ -128,8 +128,8 @@ module "web_app_service_slot_docker" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
 
-  app_service_name    = module.web_app_service_docker.name
-  app_service_id      = module.web_app_service_docker.id
+  app_service_name = module.web_app_service_docker.name
+  app_service_id   = module.web_app_service_docker.id
 
   # App service plan
   name                       = "${local.project}-app-service-slot-docker"

--- a/app_service_slot/tests/resources.tf
+++ b/app_service_slot/tests/resources.tf
@@ -1,0 +1,155 @@
+locals {
+  app_settings = {
+    # Monitoring
+    APPINSIGHTS_INSTRUMENTATIONKEY                  = azurerm_application_insights.ai.instrumentation_key
+    APPLICATIONINSIGHTS_CONNECTION_STRING           = "InstrumentationKey=${azurerm_application_insights.ai.instrumentation_key}"
+    APPINSIGHTS_PROFILERFEATURE_VERSION             = "1.0.0"
+    APPINSIGHTS_SNAPSHOTFEATURE_VERSION             = "1.0.0"
+    APPLICATIONINSIGHTS_CONFIGURATION_CONTENT       = ""
+    ApplicationInsightsAgent_EXTENSION_VERSION      = "~3"
+    DiagnosticServices_EXTENSION_VERSION            = "~3"
+    InstrumentationEngine_EXTENSION_VERSION         = "disabled"
+    SnapshotDebugger_EXTENSION_VERSION              = "disabled"
+    XDT_MicrosoftApplicationInsights_BaseExtensions = "disabled"
+    XDT_MicrosoftApplicationInsights_Mode           = "recommended"
+    XDT_MicrosoftApplicationInsights_PreemptSdk     = "disabled"
+    WEBSITE_HEALTHCHECK_MAXPINGFAILURES             = 10
+    TIMEOUT_DELAY                                   = 300
+    # Integration with private DNS (see more: https://docs.microsoft.com/en-us/answers/questions/85359/azure-app-service-unable-to-resolve-hostname-of-vi.html)
+    WEBSITE_DNS_SERVER = "168.63.129.16"
+    # Spring Environment
+
+    WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
+    WEBSITES_PORT                       = 8000
+  }
+}
+
+resource "random_id" "function_id" {
+  byte_length = 3
+}
+
+resource "azurerm_container_registry" "reg" {
+  name                = "${local.project}registry"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "Premium"
+  admin_enabled       = false
+}
+
+resource "azurerm_application_insights" "ai" {
+  name                = "${local.project}-ai"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  application_type    = "other"
+
+  tags = var.tags
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.project}-rg"
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${local.project}-vnet"
+  address_space       = var.vnet_address_space
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  tags = var.tags
+}
+
+# Subnet to host the api config
+resource "azurerm_subnet" "arm_subnet" {
+  name                 = "${local.project}-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = var.subnet_cidr
+
+  delegation {
+    name = "${local.project}-delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_service_plan" "app_docker" {
+
+  name                = "${local.project}-plan-app-service-docker"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  os_type  = "Linux"
+  sku_name = "P1v3"
+
+  tags = var.tags
+}
+
+module "web_app_service_docker" {
+  source = "../../app_service"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+
+  plan_type = "external"
+  plan_id   = azurerm_service_plan.app_docker.id
+
+  # App service plan
+  name                = "${local.project}-app-service-docker"
+  client_cert_enabled = false
+  always_on           = false
+  docker_image        = "${azurerm_container_registry.reg.login_server}/devopswebapppython"
+  docker_image_tag    = "latest"
+
+  health_check_path = "/status"
+  sku_name          = "P1v3"
+
+  app_settings = local.app_settings
+
+  allowed_ips = []
+
+  subnet_id = azurerm_subnet.arm_subnet.id
+
+  allowed_subnets = [
+    azurerm_subnet.arm_subnet.id,
+  ]
+
+  tags = var.tags
+}
+
+module "web_app_service_slot_docker" {
+  source = "../"
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+
+  app_service_name    = module.web_app_service_docker.name
+  app_service_id      = module.web_app_service_docker.id
+
+  # App service plan
+  name                       = "${local.project}-app-service-slot-docker"
+  client_certificate_enabled = false
+
+  always_on        = false
+  docker_image     = "${azurerm_container_registry.reg.login_server}/devopswebapppython"
+  docker_image_tag = "latest"
+
+  health_check_path = "/status"
+
+  app_settings = local.app_settings
+
+  allowed_ips = []
+
+  subnet_id = azurerm_subnet.arm_subnet.id
+
+  allowed_subnets = [
+    azurerm_subnet.arm_subnet.id,
+  ]
+
+  tags = var.tags
+}

--- a/app_service_slot/tests/terraform.sh
+++ b/app_service_slot/tests/terraform.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+shift 1
+other=$@
+
+subscription="MOCK_VALUE"
+
+case $action in
+    "init" | "apply" | "plan" | "destroy" )
+        # shellcheck source=/dev/null
+        if [ -e "./backend.ini" ]; then
+          source ./backend.ini
+        else
+          echo "Error: no backend.ini found!"
+          exit 1
+        fi
+
+        az account set -s "${subscription}"
+
+        terraform init
+        terraform "$action" $other
+        ;;
+    "clean" )
+        rm -rf .terraform* terraform.tfstate*
+        echo "cleaned..."
+        ;;
+    * )
+        echo "Missed action: init, apply, plan, destroy clean"
+        exit 1
+        ;;
+esac

--- a/app_service_slot/tests/variables.tf
+++ b/app_service_slot/tests/variables.tf
@@ -1,0 +1,30 @@
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+variable "prefix" {
+  description = "Resorce prefix"
+  type        = string
+  default     = "azrmtest"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "App_service example"
+  default = {
+    CreatedBy = "Terraform"
+    Source    = "https://github.com/pagopa/terraform-azurerm-v3"
+  }
+}
+
+### Custom variables
+variable "vnet_address_space" {
+  type    = list(string)
+  default = ["10.0.0.0/16"]
+}
+
+variable "subnet_cidr" {
+  type    = list(string)
+  default = ["10.0.1.0/26"]
+}

--- a/app_service_slot/variables.tf
+++ b/app_service_slot/variables.tf
@@ -32,6 +32,12 @@ variable "https_only" {
   default     = true
 }
 
+variable "client_certificate_enabled" {
+  type        = bool
+  description = "Should the function app use Client Certificates"
+  default     = false
+}
+
 variable "client_affinity_enabled" {
   type        = bool
   description = "(Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance? Defaults to false."
@@ -39,10 +45,15 @@ variable "client_affinity_enabled" {
 }
 
 ## App service slot
-
 variable "name" {
   type        = string
   description = "(Required) Specifies the name of the App Service. Changing this forces a new resource to be created."
+}
+
+variable "use_32_bit_worker_process" {
+  type        = bool
+  description = "(Optional) Should the App Service Slot run in 32 bit mode, rather than 64 bit mode? Defaults to false."
+  default     = false
 }
 
 variable "app_settings" {
@@ -54,13 +65,6 @@ variable "always_on" {
   type        = bool
   description = "(Optional) Should the app be loaded at all times? Defaults to false."
   default     = false
-}
-
-# Ex. for linux "NODE|10-lts"
-variable "linux_fx_version" {
-  type        = string
-  description = "(Optional) Linux App Framework and version for the App Service."
-  default     = null
 }
 
 variable "app_command_line" {
@@ -107,4 +111,50 @@ variable "subnet_id" {
 
 variable "tags" {
   type = map(any)
+}
+
+# Framework choice
+variable "docker_image" {
+  type    = string
+  default = null
+}
+variable "docker_image_tag" {
+  type    = string
+  default = null
+}
+variable "dotnet_version" {
+  type    = string
+  default = null
+}
+variable "go_version" {
+  type    = string
+  default = null
+}
+variable "java_server" {
+  type    = string
+  default = null
+}
+variable "java_server_version" {
+  type    = string
+  default = null
+}
+variable "java_version" {
+  type    = string
+  default = null
+}
+variable "node_version" {
+  type    = string
+  default = null
+}
+variable "php_version" {
+  type    = string
+  default = null
+}
+variable "python_version" {
+  type    = string
+  default = null
+}
+variable "ruby_version" {
+  type    = string
+  default = null
 }

--- a/app_service_slot/variables.tf
+++ b/app_service_slot/variables.tf
@@ -10,12 +10,6 @@ variable "resource_group_name" {
 }
 
 ## App service
-
-variable "app_service_plan_id" {
-  type        = string
-  description = "(Required) The ID of the App Service Plan within which to create this App Service Slot. Changing this forces a new resource to be created."
-}
-
 variable "app_service_id" {
   type        = string
   description = "(Required) The id of the App Service within which to create the App Service Slot."

--- a/app_service_slot/versions.tf
+++ b/app_service_slot/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.30.0, <= 3.45.0"
+      version = ">= 3.39.0, <= 3.45.0"
     }
   }
 }

--- a/function_app/README.md
+++ b/function_app/README.md
@@ -106,7 +106,7 @@ See [Generic resource migration](../.docs/MIGRATION_GUIDE_GENERIC_RESOURCES.md)
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.30.0, <= 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
 
 ## Modules
 

--- a/function_app/README.md
+++ b/function_app/README.md
@@ -106,7 +106,7 @@ See [Generic resource migration](../.docs/MIGRATION_GUIDE_GENERIC_RESOURCES.md)
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.30.0, <= 3.45.0 |
 
 ## Modules
 

--- a/function_app_slot/main.tf
+++ b/function_app_slot/main.tf
@@ -63,10 +63,6 @@ resource "azurerm_linux_function_app_slot" "this" {
     health_check_path   = var.health_check_path
   }
 
-  auth_settings {
-    enabled = false
-  }
-
   app_settings = merge(
     {
       # No downtime on slots swap


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Migration from azurerm_app_service_slot to azurerm_linux_web_app_slot
- Since the resource `azurerm_app_service_slot` has been deprecated in version 3.0 of the AzureRM provider, the newer `azurerm_linux_web_app_slot` resource is used in this module, thus the following variables have been:
removed:
- os_type
- app_service_plan_info/sku_tier
- linux_fx_version
- app_service_plan_id

replaced:
- min_tls_version -> minimum_tls_version
- client_cert_enabled -> client_certificate_enabled


### Motivation and context

The resource `azurerm_app_service_slot` has been deprecated in version 3.0 of the AzureRM provider, the newer `azurerm_linux_web_app_slot` resource is used in this module

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

### Other information

- Use the example Terraform template, saved in `./tests`, to test this module  and get some advices.
- Use the migrate.sh script to migrate resources from the deprecated version to the new one.
### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
