### PR TITLE
fix: Add ignore changes in storage account customer key to avoid always changed in plan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,7 @@ repos:
         args:
           - --args=--exclude-downloaded-modules
       - id: terraform_validate
-        exclude: |
-            (?x)^(
-                ^fixme*|
-                ^tests*
-            )$
+        exclude: /(tests|fixme)/i
         args:
           - --args=-json
           - --args=-no-color

--- a/data_factory/README.md
+++ b/data_factory/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.30.0, <= 3.45.0 |
 
 ## Modules
 

--- a/data_factory/README.md
+++ b/data_factory/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.30.0, <= 3.45.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.45.0 |
 
 ## Modules
 

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -79,6 +79,13 @@ resource "azurerm_storage_account" "this" {
     }
   }
 
+  # the use of storage_account_customer_managed_key resource will cause a bug on the plan: this paramenter will always see as changed.
+  lifecycle {
+    ignore_changes = [
+        customer_managed_key
+    ]
+  }
+
   tags = var.tags
 }
 

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -82,7 +82,7 @@ resource "azurerm_storage_account" "this" {
   # the use of storage_account_customer_managed_key resource will cause a bug on the plan: this paramenter will always see as changed.
   lifecycle {
     ignore_changes = [
-        customer_managed_key
+      customer_managed_key
     ]
   }
 

--- a/storage_account_customer_managed_key/tests/README.md
+++ b/storage_account_customer_managed_key/tests/README.md
@@ -1,0 +1,12 @@
+# Test for Azure module
+
+Terraform template to test the module.
+
+You need the access to DevOpsLab Subscription or change backend.ini value.
+
+`resources.tf` file contains all resources to test.
+
+## How to use it
+- ./terraform.sh plan
+- ./terraform.sh apply
+- ./terraform.sh destroy

--- a/storage_account_customer_managed_key/tests/backend.ini
+++ b/storage_account_customer_managed_key/tests/backend.ini
@@ -1,0 +1,1 @@
+subscription=DEV-IO

--- a/storage_account_customer_managed_key/tests/backend.ini
+++ b/storage_account_customer_managed_key/tests/backend.ini
@@ -1,1 +1,1 @@
-subscription=DEV-IO
+subscription=DevOpsLab

--- a/storage_account_customer_managed_key/tests/main.tf
+++ b/storage_account_customer_managed_key/tests/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.30.0, <= 3.45.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "random_id" "unique" {
+  byte_length = 3
+}
+
+data "azurerm_subscription" "current" {}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  project = "${var.prefix}${random_id.unique.hex}"
+}

--- a/storage_account_customer_managed_key/tests/outputs.tf
+++ b/storage_account_customer_managed_key/tests/outputs.tf
@@ -1,0 +1,3 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/storage_account_customer_managed_key/tests/resources.tf
+++ b/storage_account_customer_managed_key/tests/resources.tf
@@ -24,9 +24,9 @@ module "storage_account" {
   blob_change_feed_enabled             = true
   blob_change_feed_retention_in_days   = 10
   blob_restore_policy_days             = 6
-  
-  enable_identity            = true
-  
+
+  enable_identity = true
+
   tags = var.tags
 }
 
@@ -65,6 +65,6 @@ module "storage_account_customer_managed_key" {
   key_name             = "${local.project}-key"
   storage_id           = module.storage_account.id
   storage_principal_id = module.storage_account.identity.0.principal_id
-  
+
   depends_on = [azurerm_key_vault_access_policy.current_user]
 }

--- a/storage_account_customer_managed_key/tests/resources.tf
+++ b/storage_account_customer_managed_key/tests/resources.tf
@@ -55,9 +55,9 @@ resource "azurerm_key_vault_access_policy" "current_user" {
   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
 }
 
-
 module "storage_account_customer_managed_key" {
-  source               = "../../storage_account_customer_managed_key"
+  source = "../../storage_account_customer_managed_key"
+
   tenant_id            = data.azurerm_subscription.current.tenant_id
   location             = azurerm_resource_group.rg.location
   resource_group_name  = azurerm_resource_group.rg.name

--- a/storage_account_customer_managed_key/tests/resources.tf
+++ b/storage_account_customer_managed_key/tests/resources.tf
@@ -1,0 +1,70 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.project}-rg"
+  location = var.location
+
+  tags = var.tags
+}
+
+module "storage_account" {
+  source = "../../storage_account"
+
+  name                            = replace("${local.project}st", "-", "")
+  account_kind                    = "StorageV2"
+  account_tier                    = "Standard"
+  access_tier                     = "Hot"
+  account_replication_type        = "GRS"
+  resource_group_name             = azurerm_resource_group.rg.name
+  location                        = azurerm_resource_group.rg.location
+  advanced_threat_protection      = true
+  allow_nested_items_to_be_public = false
+
+  blob_versioning_enabled              = true
+  blob_container_delete_retention_days = 7
+  blob_delete_retention_days           = 7
+  blob_change_feed_enabled             = true
+  blob_change_feed_retention_in_days   = 10
+  blob_restore_policy_days             = 6
+  
+  enable_identity            = true
+  
+  tags = var.tags
+}
+
+module "key_vault" {
+  source = "../../key_vault"
+
+  name                       = "${local.project}-kv"
+  location                   = azurerm_resource_group.rg.location
+  resource_group_name        = azurerm_resource_group.rg.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 90
+
+  tags = var.tags
+}
+
+resource "azurerm_key_vault_access_policy" "current_user" {
+  key_vault_id = module.key_vault.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_client_config.current.object_id
+
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+  storage_permissions     = []
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+}
+
+
+module "storage_account_customer_managed_key" {
+  source               = "../../storage_account_customer_managed_key"
+  tenant_id            = data.azurerm_subscription.current.tenant_id
+  location             = azurerm_resource_group.rg.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  key_vault_id         = module.key_vault.id
+  key_name             = "${local.project}-key"
+  storage_id           = module.storage_account.id
+  storage_principal_id = module.storage_account.identity.0.principal_id
+  
+  depends_on = [azurerm_key_vault_access_policy.current_user]
+}

--- a/storage_account_customer_managed_key/tests/resources.tf
+++ b/storage_account_customer_managed_key/tests/resources.tf
@@ -66,5 +66,5 @@ module "storage_account_customer_managed_key" {
   storage_id           = module.storage_account.id
   storage_principal_id = module.storage_account.identity.0.principal_id
 
-  depends_on = [azurerm_key_vault_access_policy.current_user]
+  # depends_on = [azurerm_key_vault_access_policy.current_user]
 }

--- a/storage_account_customer_managed_key/tests/terraform.sh
+++ b/storage_account_customer_managed_key/tests/terraform.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+shift 1
+other=$@
+
+subscription="MOCK_VALUE"
+
+case $action in
+    "init" | "apply" | "plan" | "destroy" )
+        # shellcheck source=/dev/null
+        if [ -e "./backend.ini" ]; then
+          source ./backend.ini
+        else
+          echo "Error: no backend.ini found!"
+          exit 1
+        fi
+
+        az account set -s "${subscription}"
+
+        terraform init
+        terraform "$action" $other
+        ;;
+    "clean" )
+        rm -rf .terraform* terraform.tfstate*
+        echo "cleaned..."
+        ;;
+    * )
+        echo "Missed action: init, apply, plan, destroy clean"
+        exit 1
+        ;;
+esac

--- a/storage_account_customer_managed_key/tests/variables.tf
+++ b/storage_account_customer_managed_key/tests/variables.tf
@@ -1,0 +1,20 @@
+variable "prefix" {
+  description = "Resorce prefix"
+  type        = string
+  default     = "azrmtest"
+}
+
+variable "location" {
+  description = "Resorce location"
+  type        = string
+  default     = "westeurope"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Azurerm test tags"
+  default = {
+    CreatedBy = "Terraform"
+    Source    = "https://github.com/pagopa/terraform-azurerm-v3"
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
see commit history
<!--- Describe your changes in detail -->

### Motivation and context
The plan of a storage account with a customer managed key always see the customer_managed_key as changed. This is due to the use of the storage_account_customer_managed_key to set the customer managed key in a resource different from the storage itself.
With this PR, the changes on storage account customer managed key will be ignored (workaround).
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
