### PR TITLE
fix: PostgresSQL Flexible - Removed Monitoring categories not more used

### DIFF
--- a/postgres_flexible_server/02_monitor_flexible.tf
+++ b/postgres_flexible_server/02_monitor_flexible.tf
@@ -51,25 +51,6 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 
-  log {
-    category = "FSPGPGBouncer"
-    enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
-  }
-  log {
-    category = "PiiOBpgbouncerlog"
-    enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
-  }
-
   metric {
     category = "AllMetrics"
     enabled  = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

Actually only this categories are supported by postgres flexible diagnostic settings

<img width="650" alt="image" src="https://user-images.githubusercontent.com/92735530/225892404-8ac71b20-09bb-4c1c-a77d-af2d2bad75a4.png">


### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
