### PR TITLE
fix: Add a network rule to enable access to event hub from Azure trusted services

### DIFF
--- a/eventhub/main.tf
+++ b/eventhub/main.tf
@@ -45,6 +45,7 @@ resource "azurerm_eventhub_namespace" "this" {
           action  = ip_rule.value["action"]
         }
       }
+      trusted_service_access_enabled = network_rulesets.value["trusted_service_access_enabled"]
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a network rule to enable access to event hub from azure trusted services. The rule can be used as follows

```
network_rulesets =  [
    {
      default_action                 = "Deny"
      trusted_service_access_enabled = true
      virtual_network_rule = flatten([...])
      ip_rule = []
    }
  ] 
```

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
