### PR TITLE
fix: Set cert_allowed_uses as variable when create jwt cert

### DIFF
--- a/jwt_keys/README.md
+++ b/jwt_keys/README.md
@@ -56,6 +56,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cert_allowed_uses"></a> [cert\_allowed\_uses](#input\_cert\_allowed\_uses) | n/a | `list(string)` | <pre>[<br>  "digital_signature"<br>]</pre> | no |
 | <a name="input_cert_common_name"></a> [cert\_common\_name](#input\_cert\_common\_name) | cert info | `string` | n/a | yes |
 | <a name="input_cert_country"></a> [cert\_country](#input\_cert\_country) | n/a | `string` | `""` | no |
 | <a name="input_cert_locality"></a> [cert\_locality](#input\_cert\_locality) | n/a | `string` | `""` | no |

--- a/jwt_keys/main.tf
+++ b/jwt_keys/main.tf
@@ -8,17 +8,10 @@ resource "tls_private_key" "jwt" {
 }
 
 resource "tls_self_signed_cert" "jwt_self" {
-  allowed_uses = [
-    // "crl_signing",
-    // "data_encipherment",
-    "digital_signature",
-    // "key_agreement",
-    // "cert_signing",
-    // "key_encipherment"
-  ]
   private_key_pem       = tls_private_key.jwt.private_key_pem
   validity_period_hours = var.cert_validity_hours
   early_renewal_hours   = var.early_renewal_hours
+  allowed_uses          = var.cert_allowed_uses
   subject {
     common_name         = var.cert_common_name
     street_address      = var.cert_street_address

--- a/jwt_keys/variables.tf
+++ b/jwt_keys/variables.tf
@@ -71,3 +71,17 @@ variable "early_renewal_hours" {
   type    = number
   default = 720
 }
+
+variable "cert_allowed_uses" {
+  type = list(string)
+  default = [
+    // "crl_signing",
+    // "data_encipherment",
+    "digital_signature",
+    // "key_agreement",
+    // "cert_signing",
+    // "key_encipherment"
+  ]
+}
+
+ 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Set cert_allowed_uses as variable with default value: ["digital_signature"].
This field is currently mandatory in selfcare but not needed in pnpg.selfcare.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
