### PR TITLE
feat: Split scale set creation between crypted and not crypted os disk 

### DIFF
--- a/azure_devops_agent/README.md
+++ b/azure_devops_agent/README.md
@@ -30,7 +30,7 @@ module "azdoa_vmss_li" {
   resource_group_name = azurerm_resource_group.azdo_rg[0].name
   subnet_id           = module.azdoa_snet[0].id
   subscription        = data.azurerm_subscription.current.display_name
-
+  enable_disk_encryption = false
   tags = var.tags
 }
 
@@ -61,15 +61,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [null_resource.this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.this_encrypted](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.this_not_encrypted](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_authentication_type"></a> [authentication\_type](#input\_authentication\_type) | (Required) Type of authentication to use with the VM. Defaults to password for Windows and SSH public key for Linux. all enables both ssh and password authentication. | `string` | `"SSH"` | no |
+| <a name="input_enable_disk_encryption"></a> [enable\_disk\_encryption](#input\_enable\_disk\_encryption) | Whether to add os disk encription to the scale set instances, defaults to `false` | `bool` | `false` | no |
 | <a name="input_encryption_set_id"></a> [encryption\_set\_id](#input\_encryption\_set\_id) | (Optional) An existing encryption set | `string` | `"\"\""` | no |
-| <a name="input_image"></a> [image](#input\_image) | (Optional) The name of the operating system image as a URN alias, URN, custom image name or ID, or VHD blob URI. Valid URN format: Publisher:Offer:Sku:Version. | `string` | `"UbuntuLTS"` | no |
+| <a name="input_image"></a> [image](#input\_image) | (Optional) The name of the operating system image as a URN alias, URN, custom image name or ID, or VHD blob URI. Valid URN format: Publisher:Offer:Sku:Version. | `string` | `"Ubuntu2204"` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the Linux Virtual Machine Scale Set. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the Resource Group in which the Linux Virtual Machine Scale Set should be exist. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_storage_sku"></a> [storage\_sku](#input\_storage\_sku) | (Optional) The SKU of the storage account with which to persist VM. Use a singular sku that would be applied across all disks, or specify individual disks. Usage: [--storage-sku SKU \| --storage-sku ID=SKU ID=SKU ID=SKU...], where each ID is os or a 0-indexed lun. Allowed values: Standard\_LRS, Premium\_LRS, StandardSSD\_LRS, UltraSSD\_LRS, Premium\_ZRS, StandardSSD\_ZRS. | `string` | `"StandardSSD_LRS"` | no |

--- a/azure_devops_agent/main.tf
+++ b/azure_devops_agent/main.tf
@@ -1,17 +1,20 @@
-resource "null_resource" "this" {
+resource "null_resource" "this_encrypted" {
   # needs az cli > 2.0.81
   # see https://github.com/Azure/azure-cli/issues/12152
+
+  count = var.enable_disk_encryption ? 1 : 0
 
   triggers = {
     name                = var.name
     resource_group_name = var.resource_group_name
     subscription        = var.subscription
     config_json         = "${sha1(file("${path.module}/script-config.json"))}"
+    config_script       = "${sha1(file("${path.module}/script-config.sh"))}"
+    encryption          = var.enable_disk_encryption
   }
 
   provisioner "local-exec" {
     command = <<EOT
-      # az login --service-principal --username $ARM_CLIENT_ID --password $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID && \
       az account set -s ${var.subscription} && \
       az vmss create \
         --admin-username azureuser \
@@ -29,6 +32,64 @@ resource "null_resource" "this" {
         --platform-fault-domain-count 1 \
         --load-balancer "" \
         --os-disk-encryption-set ${var.encryption_set_id} \
+        --subnet ${var.subnet_id} && \
+      az vmss extension set \
+        --vmss-name ${var.name} \
+        --resource-group ${var.resource_group_name} \
+        --name CustomScript \
+        --version 2.0 \
+        --publisher Microsoft.Azure.Extensions \
+        --extension-instance-name install_requirements \
+        --settings "${path.module}/script-config.json"
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<EOT
+      # az login --service-principal --username $ARM_CLIENT_ID --password $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID && \
+      az account set -s ${self.triggers.subscription} && \
+      az vmss delete \
+        --name ${self.triggers.name} \
+        --resource-group ${self.triggers.resource_group_name}
+    EOT
+  }
+}
+
+
+resource "null_resource" "this_not_encrypted" {
+  # needs az cli > 2.0.81
+  # see https://github.com/Azure/azure-cli/issues/12152
+
+  count = var.enable_disk_encryption ? 0 : 1
+
+  triggers = {
+    name                = var.name
+    resource_group_name = var.resource_group_name
+    subscription        = var.subscription
+    config_json         = "${sha1(file("${path.module}/script-config.json"))}"
+    config_script       = "${sha1(file("${path.module}/script-config.sh"))}"
+    encryption          = var.enable_disk_encryption
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      az account set -s ${var.subscription} && \
+      az vmss create \
+        --admin-username azureuser \
+        --name ${var.name} \
+        --resource-group ${var.resource_group_name} \
+        --image ${var.image} \
+        --vm-sku ${var.vm_sku} \
+        --storage-sku ${var.storage_sku} \
+        --authentication-type ${var.authentication_type} \
+        --generate-ssh-keys \
+        --instance-count 2 \
+        --disable-overprovision \
+        --upgrade-policy-mode manual \
+        --single-placement-group false \
+        --platform-fault-domain-count 1 \
+        --load-balancer "" \
         --subnet ${var.subnet_id} && \
       az vmss extension set \
         --vmss-name ${var.name} \

--- a/azure_devops_agent/script-config.json
+++ b/azure_devops_agent/script-config.json
@@ -1,6 +1,6 @@
 {
   "fileUris": [
-    "https://raw.githubusercontent.com/pagopa/azurerm/main/azure_devops_agent/script-config.sh"
+    "https://raw.githubusercontent.com/pagopa/terraform-azurerm-v3/main/azure_devops_agent/script-config.sh"
   ],
   "commandToExecute": "./script-config.sh"
 }

--- a/azure_devops_agent/script-config.sh
+++ b/azure_devops_agent/script-config.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
-# install zip unzip
-
+# install zip unzip ca-certificates curl wget apt-transport-https lsb-release gnupg jq
 apt-get -y update
-apt-get -y install zip unzip
+apt-get -y install zip unzip ca-certificates curl wget apt-transport-https lsb-release gnupg jq
 
-# install az cli from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
+zip --version
+echo "✅ zip installed"
+unzip --version
+echo "✅ unzip installed"
+jq
+echo "✅ jq installed"
 
-apt-get -y update
-apt-get -y install ca-certificates curl wget apt-transport-https lsb-release gnupg
-
+# setup az CLI installation from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
 curl -sL https://packages.microsoft.com/keys/microsoft.asc |
     gpg --dearmor |
     tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
@@ -18,15 +20,7 @@ AZ_REPO=$(lsb_release -cs)
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
     tee /etc/apt/sources.list.d/azure-cli.list
 
-apt-get -y update
-apt-get -y install azure-cli
-
-# install python package index (pip)
-
-apt-get -y install python-pip
-
-# install docker from https://docs.docker.com/engine/install/ubuntu/
-
+# setup Docker installation from https://docs.docker.com/engine/install/ubuntu/
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
     gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
@@ -34,49 +28,44 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-apt-get -y update
-apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-# install kubectl from https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
-
+# setup kubectl installation from https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
 curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-
 echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 
-apt-get -y update
-apt-get -y install kubectl
-
-# install helm from https://helm.sh/docs/intro/install/#from-apt-debianubuntu
-
+# setup helm installation from https://helm.sh/docs/intro/install/#from-apt-debianubuntu
 curl https://baltocdn.com/helm/signing.asc | apt-key add -
-
 echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
 
 apt-get -y update
-apt-get -y install helm
+apt-get -y install azure-cli python3-pip docker-ce docker-ce-cli containerd.io docker-compose-plugin kubectl helm
+
+az --version
+echo "✅ az-cli installed"
+kubectl version
+echo "✅ kubectl installed"
+docker -v
+echo "✅ docker installed"
+helm version
+echo "✅ helm installed"
+python3 --version
+echo "✅ python3 installed"
 
 # install yq from https://github.com/mikefarah/yq#install
-
-YQ_VERSION="v4.27.2"
+YQ_VERSION="v4.33.3"
 YQ_BINARY="yq_linux_amd64"
 wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz -O - |\
   tar xz && mv ${YQ_BINARY} /usr/bin/yq
 
-# install zip unzip
-
-apt-get -y update
-apt-get -y install zip unzip
+yq --version
+echo "✅ yq installed"
 
 # install SOPS from https://github.com/mozilla/sops
 SOPS_VERSION="v3.7.3"
 SOPS_BINARY="3.7.3_amd64.deb"
+wget https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops_${SOPS_BINARY} | apt install -y $PWD/sops_${SOPS_BINARY}
 
-wget https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops_${SOPS_BINARY} |apt install -y $PWD/sops_${SOPS_BINARY}
-
-# install jq
-
-apt-get -y update
-apt-get -y install jq
+sops -v
+echo "✅ sops installed"
 
 # prepare machine for k6 large load test
 

--- a/azure_devops_agent/variables.tf
+++ b/azure_devops_agent/variables.tf
@@ -16,7 +16,7 @@ variable "resource_group_name" {
 variable "image" {
   type        = string
   description = "(Optional) The name of the operating system image as a URN alias, URN, custom image name or ID, or VHD blob URI. Valid URN format: Publisher:Offer:Sku:Version."
-  default     = "UbuntuLTS"
+  default     = "Ubuntu2204"
 }
 
 variable "vm_sku" {
@@ -55,6 +55,12 @@ variable "encryption_set_id" {
   type        = string
   description = "(Optional) An existing encryption set"
   default     = "\"\""
+}
+
+variable "enable_disk_encryption" {
+  type        = bool
+  description = "Whether to add os disk encription to the scale set instances, defaults to `false`"
+  default     = false
 }
 
 variable "tags" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
split resource creation between crypted os disk and not crypted, to avoid errors when creating a new SS

updated setup script for new os (Ubuntu 22.04)


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
