### PR TITLE
fix: Function app maximum_elastic_worker_count

### DIFF
--- a/cert_mounter/README.md
+++ b/cert_mounter/README.md
@@ -29,7 +29,7 @@ module "cert_mounter" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.9.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.7.1 |
 
 ## Modules
 

--- a/function_app/main.tf
+++ b/function_app/main.tf
@@ -222,7 +222,7 @@ resource "azurerm_service_plan" "this" {
   os_type                      = "Linux"
   sku_name                     = var.app_service_plan_info.sku_size
   zone_balancing_enabled       = var.app_service_plan_info.zone_balancing_enabled
-  maximum_elastic_worker_count = var.app_service_plan_info.maximum_elastic_worker_count
+  maximum_elastic_worker_count = var.app_service_plan_info.kind == "elastic" ? var.app_service_plan_info.maximum_elastic_worker_count : null
   worker_count                 = var.app_service_plan_info.worker_count
 
   per_site_scaling_enabled = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

maximum_elastic_worker_count must be specified only for elastic plan
For Linux plan must be null

example
https://github.com/pagopa/io-services-cms/actions/runs/5277560078/jobs/9545822678

```
│ Error: `maximum_elastic_worker_count` can only be specified with Elastic Premium Skus
│ 
│   with module.webapp_functions_app.azurerm_service_plan.this[0],
│   on .terraform/modules/webapp_functions_app/function_app/main.tf line 216, in resource "azurerm_service_plan" "this":
│  216: resource "azurerm_service_plan" "this" {
│ 
│ `maximum_elastic_worker_count` can only be specified with Elastic Premium
│ Skus
```

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
