### PR TITLE
feat: Module for GitHub self hosted runner on Azure Container Apps Jobs

### DIFF
--- a/container_app_job_gh_runner/README.md
+++ b/container_app_job_gh_runner/README.md
@@ -1,0 +1,76 @@
+# Azure Container App Job as GitHub Runners
+
+This module creates the infrastructure to host GitHub self hosted runners using Azure Container Apps jobs.
+
+## Included resources
+
+The following resources are created and managed by this module:
+
+- resource group
+- subnet
+- container app environment
+- container app job
+
+## How to use it
+
+Give a try to the example saved in `terraform-azurerm-v3/container_app_job_gh_runner/tests` to see a working demo of this module
+
+### Prerequisites
+
+Before running the demo, you need to manually create:
+
+- vnet
+- keyvault
+- a valid GitHub PAT stored as secret
+
+Names of these resources are required as module input
+
+<!-- markdownlint-disable -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | <= 1.9.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.44.0, <= 3.76.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azapi_resource.runner_environment](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
+| [azapi_resource.runner_job](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
+| [azurerm_key_vault_access_policy.keyvault_containerapp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_resource_group.runner_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.runner_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app"></a> [app](#input\_app) | n/a | <pre>object({<br>    repo_owner = optional(string, "pagopa")<br>    repos      = set(string)<br>    image      = optional(string, "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47")<br>  })</pre> | n/a | yes |
+| <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Short environment prefix | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br>    workspace_id = string<br>    customerId   = string<br>    sharedKey    = string<br>  })</pre> | n/a | yes |
+| <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | n/a | <pre>object({<br>    resource_group_name = string<br>    name                = string<br>    secret_name         = string<br>  })</pre> | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Resource group and identity location | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | n/a | <pre>object({<br>    rg_vnet      = string<br>    vnet         = string<br>    cidr_subnets = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Project prefix | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Identity tags | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ca_name"></a> [ca\_name](#output\_ca\_name) | Container App job name |
+| <a name="output_cae_name"></a> [cae\_name](#output\_cae\_name) | Container App Environment name |
+| <a name="output_resource_group"></a> [resource\_group](#output\_resource\_group) | Resource group name |
+| <a name="output_subnet_cidr"></a> [subnet\_cidr](#output\_subnet\_cidr) | Subnet CIDR blocks |
+| <a name="output_subnet_name"></a> [subnet\_name](#output\_subnet\_name) | Subnet name |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/container_app_job_gh_runner/README.md
+++ b/container_app_job_gh_runner/README.md
@@ -59,10 +59,10 @@ No modules.
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Short environment prefix | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | <pre>object({<br>    workspace_id = string<br>    customerId   = string<br>    sharedKey    = string<br>  })</pre> | n/a | yes |
 | <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | n/a | <pre>object({<br>    resource_group_name = string<br>    name                = string<br>    secret_name         = string<br>  })</pre> | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | Resource group and identity location | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Resource group and resources location | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | n/a | <pre>object({<br>    rg_vnet      = string<br>    vnet         = string<br>    cidr_subnets = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Project prefix | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Identity tags | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags for new resources | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
 
 ## Outputs
 

--- a/container_app_job_gh_runner/locals.tf
+++ b/container_app_job_gh_runner/locals.tf
@@ -1,0 +1,49 @@
+locals {
+  name                = "${var.prefix}-${var.env_short}"
+  resource_group_name = "${local.name}-github-runner-rg"
+
+  rules = [for repo in var.app.repos :
+    {
+      name = "github-runner-${repo}"
+      type = "github-runner"
+      metadata = {
+        owner                     = var.app.repo_owner
+        runnerScope               = "repo"
+        repos                     = "${repo}"
+        targetWorkflowQueueLength = "1"
+        labels                    = "github-runner-${repo}"
+      }
+      auth = [
+        {
+          secretRef        = "personal-access-token"
+          triggerParameter = "personalAccessToken"
+        }
+      ]
+    }
+  ]
+
+  containers = [for repo in var.app.repos :
+    {
+      env = [
+        {
+          name      = "GITHUB_PAT"
+          secretRef = "personal-access-token"
+        },
+        {
+          name  = "REPO_URL"
+          value = "https://github.com/${var.app.repo_owner}/${repo}"
+        },
+        {
+          name  = "REGISTRATION_TOKEN_API_URL"
+          value = "https://api.github.com/repos/${var.app.repo_owner}/${repo}/actions/runners/registration-token"
+        }
+      ]
+      image = var.app.image
+      name  = "github-runner-${repo}"
+      resources = {
+        cpu    = 1.0
+        memory = "2Gi"
+      }
+    }
+  ]
+}

--- a/container_app_job_gh_runner/main.tf
+++ b/container_app_job_gh_runner/main.tf
@@ -1,0 +1,97 @@
+data "azurerm_key_vault" "key_vault" {
+  resource_group_name = var.key_vault.resource_group_name
+  name                = var.key_vault.name
+}
+
+resource "azurerm_resource_group" "runner_rg" {
+  name     = local.resource_group_name
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_subnet" "runner_subnet" {
+  name                 = "${local.name}-github-runner-snet"
+  resource_group_name  = var.network.rg_vnet
+  virtual_network_name = var.network.vnet
+  address_prefixes     = var.network.cidr_subnets
+  service_endpoints    = []
+}
+
+resource "azapi_resource" "runner_environment" {
+  type      = "Microsoft.App/managedEnvironments@2023-05-01"
+  name      = "${local.name}-github-runner-cae"
+  location  = azurerm_resource_group.runner_rg.location
+  parent_id = azurerm_resource_group.runner_rg.id
+
+  tags = var.tags
+
+  body = jsonencode({
+    properties = {
+      appLogsConfiguration = {
+        destination = "log-analytics"
+        logAnalyticsConfiguration = {
+          customerId = var.environment.customerId
+          sharedKey  = var.environment.sharedKey
+        }
+      }
+      zoneRedundant = true
+      vnetConfiguration = {
+        infrastructureSubnetId = azurerm_subnet.runner_subnet.id
+        internal               = true
+      }
+    }
+  })
+}
+
+resource "azapi_resource" "runner_job" {
+  type      = "Microsoft.App/jobs@2023-05-01"
+  name      = "${local.name}-github-runner-job"
+  location  = azurerm_resource_group.runner_rg.location
+  parent_id = azurerm_resource_group.runner_rg.id
+
+  tags = var.tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  body = jsonencode({
+    properties = {
+      environmentId = azapi_resource.runner_environment.id
+      configuration = {
+        replicaRetryLimit = 1
+        replicaTimeout    = 1800
+        eventTriggerConfig = {
+          parallelism            = 1
+          replicaCompletionCount = 1
+          scale = {
+            maxExecutions   = 10
+            minExecutions   = 0
+            pollingInterval = 20
+            rules           = local.rules
+          }
+        }
+        secrets = [{
+          keyVaultUrl = "${data.azurerm_key_vault.key_vault.vault_uri}secrets/${var.key_vault.secret_name}" # no versioning
+          identity    = "system"
+          name        = "personal-access-token"
+        }]
+        triggerType = "Event"
+      }
+      template = {
+        containers = local.containers
+      }
+    }
+  })
+}
+
+resource "azurerm_key_vault_access_policy" "keyvault_containerapp" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  tenant_id    = azapi_resource.runner_job.identity[0].tenant_id
+  object_id    = azapi_resource.runner_job.identity[0].principal_id
+
+  secret_permissions = [
+    "Get",
+  ]
+}

--- a/container_app_job_gh_runner/outputs.tf
+++ b/container_app_job_gh_runner/outputs.tf
@@ -1,0 +1,24 @@
+output "resource_group" {
+  value       = azurerm_resource_group.runner_rg.name
+  description = "Resource group name"
+}
+
+output "subnet_name" {
+  value       = azurerm_subnet.runner_subnet.name
+  description = "Subnet name"
+}
+
+output "subnet_cidr" {
+  value       = azurerm_subnet.runner_subnet.address_prefixes
+  description = "Subnet CIDR blocks"
+}
+
+output "cae_name" {
+  value       = azapi_resource.runner_environment.name
+  description = "Container App Environment name"
+}
+
+output "ca_name" {
+  value       = azapi_resource.runner_job.name
+  description = "Container App job name"
+}

--- a/container_app_job_gh_runner/tests/backend.ini
+++ b/container_app_job_gh_runner/tests/backend.ini
@@ -1,0 +1,1 @@
+subscription=DevOpsLab

--- a/container_app_job_gh_runner/tests/main.tf
+++ b/container_app_job_gh_runner/tests/main.tf
@@ -25,10 +25,17 @@ provider "azurerm" {
   }
 }
 
+data "azurerm_client_config" "current" {
+}
+
 resource "random_id" "unique" {
   byte_length = 3
 }
 
 locals {
-  project = "${var.prefix}${random_id.unique.hex}"
+  project        = "${var.prefix}${random_id.unique.hex}"
+  env_short      = substr(random_id.unique.hex, 0, 1)
+  rg_name        = "${local.project}-${local.env_short}-github-runner-rg"
+  key_vault_name = "${local.project}-${local.env_short}-kv"
+  vnet_name      = "${local.project}-${local.env_short}-vnet"
 }

--- a/container_app_job_gh_runner/tests/main.tf
+++ b/container_app_job_gh_runner/tests/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<= 3.76.0"
+    }
+
+    azapi = {
+      source  = "azure/azapi"
+      version = "<= 1.9.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "random_id" "unique" {
+  byte_length = 3
+}
+
+locals {
+  project = "${var.prefix}${random_id.unique.hex}"
+}

--- a/container_app_job_gh_runner/tests/output.tf
+++ b/container_app_job_gh_runner/tests/output.tf
@@ -1,0 +1,28 @@
+output "random_id" {
+  value = random_id.unique.hex
+}
+
+output "resource_group" {
+  value       = module.runner.resource_group
+  description = "Resource group name"
+}
+
+output "subnet_name" {
+  value       = module.runner.subnet_name
+  description = "Subnet name"
+}
+
+output "subnet_cidr" {
+  value       = module.runner.subnet_cidr
+  description = "Subnet CIDR blocks"
+}
+
+output "cae_name" {
+  value       = module.runner.cae_name
+  description = "Container App Environment name"
+}
+
+output "ca_name" {
+  value       = module.runner.ca_name
+  description = "Container App job name"
+}

--- a/container_app_job_gh_runner/tests/resources.tf
+++ b/container_app_job_gh_runner/tests/resources.tf
@@ -12,14 +12,14 @@ module "runner" {
     secret_name         = var.key_vault.secret_name
   }
 
-  # this creates a subnet in the specified vnet using CIDR block set here. Set /23 CIDR block
+  # creates a subnet in the specified existing vnet. Use a /23 CIDR block
   network = {
     rg_vnet      = var.network.rg_vnet
     vnet         = var.network.vnet
     cidr_subnets = var.network.cidr_subnets
   }
 
-  # set reference to the log analytics workspace you want to use to log
+  # set reference to the log analytics workspace you want to use for logging
   environment = {
     workspace_id = var.environment.workspace_id
     customerId   = var.environment.customerId

--- a/container_app_job_gh_runner/tests/resources.tf
+++ b/container_app_job_gh_runner/tests/resources.tf
@@ -1,0 +1,32 @@
+module "runner" {
+  source = "../"
+
+  location  = var.location
+  prefix    = var.prefix
+  env_short = substr(random_id.unique.hex, 0, 1)
+
+  key_vault = {
+    resource_group_name = var.key_vault.resource_group_name
+    name                = var.key_vault.name
+    secret_name         = var.key_vault.secret_name
+  }
+
+  network = {
+    rg_vnet      = var.network.rg_vnet
+    vnet         = var.network.vnet
+    cidr_subnets = var.network.cidr_subnets
+  }
+
+  environment = {
+    workspace_id = var.environment.workspace_id
+    customerId   = var.environment.customerId
+    sharedKey    = var.environment.sharedKey
+  }
+
+  app = {
+    repos      = var.app.repos
+    repo_owner = var.app.repo_owner
+  }
+
+  tags = var.tags
+}

--- a/container_app_job_gh_runner/tests/resources.tf
+++ b/container_app_job_gh_runner/tests/resources.tf
@@ -1,21 +1,46 @@
+resource "azurerm_resource_group" "rg" {
+  name     = local.rg_name
+  location = var.location
+}
+
+#tfsec:ignore:azure-keyvault-specify-network-acl
+#tfsec:ignore:azure-keyvault-no-purge
+resource "azurerm_key_vault" "key_vault" {
+  resource_group_name           = azurerm_resource_group.rg.name
+  name                          = local.key_vault_name
+  sku_name                      = "standard"
+  location                      = azurerm_resource_group.rg.location
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  public_network_access_enabled = true
+  soft_delete_retention_days    = 7
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  resource_group_name = azurerm_resource_group.rg.name
+  name                = local.vnet_name
+  location            = azurerm_resource_group.rg.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+# module to use
 module "runner" {
   source = "../" # change me with module URI
 
   location  = var.location
   prefix    = var.prefix
-  env_short = substr(random_id.unique.hex, 0, 1) # change me with your env
+  env_short = local.env_short # change me with your env
 
   # set reference to the secret which holds the GitHub PAT with access to your repos
   key_vault = {
-    resource_group_name = var.key_vault.resource_group_name
-    name                = var.key_vault.name
+    resource_group_name = azurerm_key_vault.key_vault.resource_group_name
+    name                = azurerm_key_vault.key_vault.name
     secret_name         = var.key_vault.secret_name
   }
 
   # creates a subnet in the specified existing vnet. Use a /23 CIDR block
   network = {
-    rg_vnet      = var.network.rg_vnet
-    vnet         = var.network.vnet
+    rg_vnet      = azurerm_virtual_network.vnet.resource_group_name
+    vnet         = azurerm_virtual_network.vnet.name
     cidr_subnets = var.network.cidr_subnets
   }
 

--- a/container_app_job_gh_runner/tests/resources.tf
+++ b/container_app_job_gh_runner/tests/resources.tf
@@ -1,28 +1,32 @@
 module "runner" {
-  source = "../"
+  source = "../" # change me with module URI
 
   location  = var.location
   prefix    = var.prefix
-  env_short = substr(random_id.unique.hex, 0, 1)
+  env_short = substr(random_id.unique.hex, 0, 1) # change me with your env
 
+  # set reference to the secret which holds the GitHub PAT with access to your repos
   key_vault = {
     resource_group_name = var.key_vault.resource_group_name
     name                = var.key_vault.name
     secret_name         = var.key_vault.secret_name
   }
 
+  # this creates a subnet in the specified vnet using CIDR block set here. Set /23 CIDR block
   network = {
     rg_vnet      = var.network.rg_vnet
     vnet         = var.network.vnet
     cidr_subnets = var.network.cidr_subnets
   }
 
+  # set reference to the log analytics workspace you want to use to log
   environment = {
     workspace_id = var.environment.workspace_id
     customerId   = var.environment.customerId
     sharedKey    = var.environment.sharedKey
   }
 
+  # set app properties - especially the list of repos to support
   app = {
     repos      = var.app.repos
     repo_owner = var.app.repo_owner

--- a/container_app_job_gh_runner/tests/terraform.sh
+++ b/container_app_job_gh_runner/tests/terraform.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+action=$1
+shift 1
+other=$@
+
+subscription="MOCK_VALUE"
+
+case $action in
+    "init" | "apply" | "plan" | "destroy" )
+        # shellcheck source=/dev/null
+        if [ -e "./backend.ini" ]; then
+          source ./backend.ini
+        else
+          echo "Error: no backend.ini found!"
+          exit 1
+        fi
+
+        az account set -s "${subscription}"
+
+        terraform init
+        terraform "$action" $other
+        ;;
+    "clean" )
+        rm -rf .terraform* terraform.tfstate*
+        echo "cleaned..."
+        ;;
+    * )
+        echo "Missed action: init, apply, plan, destroy clean"
+        exit 1
+        ;;
+esac

--- a/container_app_job_gh_runner/tests/variables.tf
+++ b/container_app_job_gh_runner/tests/variables.tf
@@ -28,7 +28,7 @@ variable "key_vault" {
   default = {
     resource_group_name = "azrmtest-keyvault-rg"
     name                = "azrmtest-keyvault"
-    secret_name         = "gh_pat"
+    secret_name         = "gh-pat"
   }
 }
 
@@ -62,5 +62,8 @@ variable "app" {
 
   default = {
     repo_owner = "pagopa"
+    repos = [
+      "terraform-azurerm-v3"
+    ]
   }
 }

--- a/container_app_job_gh_runner/tests/variables.tf
+++ b/container_app_job_gh_runner/tests/variables.tf
@@ -1,0 +1,66 @@
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+variable "prefix" {
+  description = "Resorce prefix"
+  type        = string
+  default     = "azrmtest"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of tags"
+  default = {
+    CreatedBy = "Terraform"
+    Source    = "https://github.com/pagopa/terraform-azurerm-v3"
+  }
+}
+
+variable "key_vault" {
+  type = object({
+    resource_group_name = string
+    name                = string
+    secret_name         = string
+  })
+
+  default = {
+    resource_group_name = "azrmtest-keyvault-rg"
+    name                = "azrmtest-keyvault"
+    secret_name         = "gh_pat"
+  }
+}
+
+variable "network" {
+  type = object({
+    rg_vnet      = string
+    vnet         = string
+    cidr_subnets = list(string)
+  })
+
+  default = {
+    rg_vnet      = "azrmtest-vnet-rg"
+    vnet         = "azrmtest-vnet"
+    cidr_subnets = ["10.0.2.0/23"]
+  }
+}
+
+variable "environment" {
+  type = object({
+    workspace_id = string
+    customerId   = string
+    sharedKey    = string
+  })
+}
+
+variable "app" {
+  type = object({
+    repos      = optional(set(string))
+    repo_owner = string
+  })
+
+  default = {
+    repo_owner = "pagopa"
+  }
+}

--- a/container_app_job_gh_runner/variables.tf
+++ b/container_app_job_gh_runner/variables.tf
@@ -1,6 +1,6 @@
 variable "tags" {
   type        = map(any)
-  description = "Identity tags"
+  description = "Tags for new resources"
   default = {
     CreatedBy = "Terraform"
   }
@@ -8,7 +8,7 @@ variable "tags" {
 
 variable "location" {
   type        = string
-  description = "Resource group and identity location"
+  description = "Resource group and resources location"
 }
 
 variable "prefix" {
@@ -17,7 +17,7 @@ variable "prefix" {
 
   validation {
     condition = (
-      length(var.prefix) < 8
+      length(var.prefix) < 6
     )
     error_message = "Max length is 6 chars."
   }
@@ -29,9 +29,9 @@ variable "env_short" {
 
   validation {
     condition = (
-      length(var.env_short) <= 1
+      length(var.env_short) == 1
     )
-    error_message = "Max length is 1 chars."
+    error_message = "Length is 1 chars."
   }
 }
 
@@ -41,6 +41,13 @@ variable "network" {
     vnet         = string
     cidr_subnets = list(string)
   })
+
+  validation {
+    condition = (
+      length(var.network.cidr_subnets) >= 1
+    )
+    error_message = "CIDR block must be supplied"
+  }
 }
 
 variable "environment" {
@@ -57,6 +64,13 @@ variable "app" {
     repos      = set(string)
     image      = optional(string, "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47")
   })
+
+  validation {
+    condition = (
+      length(var.app.repos) >= 1
+    )
+    error_message = "List of repos must supplied"
+  }
 }
 
 variable "key_vault" {

--- a/container_app_job_gh_runner/variables.tf
+++ b/container_app_job_gh_runner/variables.tf
@@ -1,0 +1,68 @@
+variable "tags" {
+  type        = map(any)
+  description = "Identity tags"
+  default = {
+    CreatedBy = "Terraform"
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "Resource group and identity location"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Project prefix"
+
+  validation {
+    condition = (
+      length(var.prefix) < 8
+    )
+    error_message = "Max length is 6 chars."
+  }
+}
+
+variable "env_short" {
+  type        = string
+  description = "Short environment prefix"
+
+  validation {
+    condition = (
+      length(var.env_short) <= 1
+    )
+    error_message = "Max length is 1 chars."
+  }
+}
+
+variable "network" {
+  type = object({
+    rg_vnet      = string
+    vnet         = string
+    cidr_subnets = list(string)
+  })
+}
+
+variable "environment" {
+  type = object({
+    workspace_id = string
+    customerId   = string
+    sharedKey    = string
+  })
+}
+
+variable "app" {
+  type = object({
+    repo_owner = optional(string, "pagopa")
+    repos      = set(string)
+    image      = optional(string, "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47")
+  })
+}
+
+variable "key_vault" {
+  type = object({
+    resource_group_name = string
+    name                = string
+    secret_name         = string
+  })
+}

--- a/container_app_job_gh_runner/variables.tf
+++ b/container_app_job_gh_runner/variables.tf
@@ -67,7 +67,7 @@ variable "app" {
 
   validation {
     condition = (
-      length(var.app.repos) >= 1
+      var.app.repos != null && length(var.app.repos) >= 1
     )
     error_message = "List of repos must supplied"
   }

--- a/container_app_job_gh_runner/versions.tf
+++ b/container_app_job_gh_runner/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.44.0, <= 3.76.0"
+    }
+
+    azapi = {
+      source  = "azure/azapi"
+      version = "<= 1.9.0"
+    }
+  }
+}
+
+data "azurerm_subscription" "current" {}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Adds a module to make easier and reusable the creation of self-hosted GitHub runners on Azure Container Apps jobs.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This feature adds a new module that can be used by repositories which need private resource access on Azure. Since  every repository might need to run Actions against private resources in Azure, I think that creating a new module is worthing because it can help developers maximising code reusability and helping cloud engineers to keep environment consistent (naming, resource organization, etc.) across multiple products.

Before using the module, developer needs the following existing resources:
- a VNet
- a KeyVault
- a secret in the mentioned KeyVault containing a GitHub PAT with access to the desired repos

The module creates:
- a subnet
- a resource group
- a Container App Environment
- a Container App job
- a role assignment to allow the container app job to read the secret (`Get` permission over KeyVault's `secrets`)

#### Design
A Container App job scales jobs based on event-driven rules (KEDA). To support GitHub Actions, you need to use [`github-runner` scale rule](https://keda.sh/docs/2.12/scalers/github-runner/) with these metadata:
- owner: `pagopa`
- runnerScope: `repo`
  - most tighten
- repos: *the repository* you want to support
  - it supports multiple repositories but we need a 1:1 match between containers and repositories
- targetWorkflowQueueLength: `1`
  - indicates how many job requests are necessary to trigger the container
- labels: the job name
  - field is optional but allows us to set a 1:1 match between containers and repositories

With the above settings, the app will be able to poll the GitHub repository (be careful to quota limits). When a job request is detected, it launches the job indicated in the `labels` metadata.

On the other hand, containers needs these environment variables to connect to GitHub, [grab a registration token and register themself as runners](https://github.com/pagopa/github-self-hosted-runner-azure/blob/dockerfile-v2/github-runner-entrypoint.sh):
- GITHUB_PAT: reference to the KeyVault secret (no Kubernetes secrets are used)
- REPO_URL: GitHub repo URL
- REGISTRATION_TOKEN_API_URL: [GitHub API](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-a-registration-token-for-a-repository) to get the registration token

#### Notes
`azapi_resource` is required by CAE because:
- `zoneRedundant` property must be true but `azurerm` supports it since v3.50 (too recent for us?)

`azapi_resource` is required by CA because:
- `azurerm` doesn't support Container App *jobs* ([feature request](https://github.com/hashicorp/terraform-provider-azurerm/issues/23165))
- KeyVault reference not supported by `azurerm` ([feature request](https://github.com/hashicorp/terraform-provider-azurerm/issues/21739))

### Type of changes

- [X] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
