### PR TITLE
fix: Improvements to GitHub identity module at first deployment

### DIFF
--- a/github_federated_identity/main.tf
+++ b/github_federated_identity/main.tf
@@ -24,7 +24,7 @@ data "azurerm_resource_group" "resource_group_details" {
 }
 
 locals {
-  rg_roles = toset(flatten([
+  rg_roles = tolist(flatten([
     for rg in data.azurerm_resource_group.resource_group_details : [
       for role in var.identity_role == "ci" ? var.ci_rbac_roles.resource_groups[rg.name] : var.cd_rbac_roles.resource_groups[rg.name] : {
         resource_group_id = rg.id
@@ -35,9 +35,9 @@ locals {
 }
 
 resource "azurerm_role_assignment" "identity_rg_role_assignment" {
-  for_each             = { for r in local.rg_roles : "${r.resource_group_id}.${r.role_name}" => r } # key must be unique
-  scope                = each.value.resource_group_id
-  role_definition_name = each.value.role_name
+  count                = length(local.rg_roles)
+  scope                = local.rg_roles[count.index].resource_group_id
+  role_definition_name = local.rg_roles[count.index].role_name
   principal_id         = azurerm_user_assigned_identity.identity.principal_id
 }
 

--- a/github_federated_identity/tests/resources.tf
+++ b/github_federated_identity/tests/resources.tf
@@ -26,8 +26,6 @@ module "identity-ci" {
   # ci/d_rbac_roles is optional. Default gives Reader (CI) and Contributor (CD) roles on current subscription
 
   tags = var.tags
-
-  depends_on = [azurerm_resource_group.identity_rg]
 }
 
 # everything as above, except for write roles
@@ -56,6 +54,4 @@ module "identity-cd" {
   ]
 
   tags = var.tags
-
-  depends_on = [azurerm_resource_group.identity_rg]
 }

--- a/github_federated_identity/tests/resources.tf
+++ b/github_federated_identity/tests/resources.tf
@@ -26,6 +26,8 @@ module "identity-ci" {
   # ci/d_rbac_roles is optional. Default gives Reader (CI) and Contributor (CD) roles on current subscription
 
   tags = var.tags
+
+  depends_on = [azurerm_resource_group.identity_rg]
 }
 
 # everything as above, except for write roles
@@ -40,7 +42,7 @@ module "identity-cd" {
   cd_rbac_roles = {         # explicit definition, so default Contributor role is not assigned to the current subscription
     subscription_roles = [] # empty array means no permission over the current subscription
     resource_groups = {     # map of resource groups with list of roles to assign
-      "${var.prefix}-${local.env_short}-identity-rg" = [
+      "terraform-state-rg" = [
         "Contributor"
       ]
     }
@@ -54,4 +56,6 @@ module "identity-cd" {
   ]
 
   tags = var.tags
+
+  depends_on = [azurerm_resource_group.identity_rg]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Fixed an issue where resource group IAM permissions assignment works but at the first deployment for some weird reason

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Having a failure at the first deployment attempt  forcing you to apply the Terraform configuration twice wasn't that nice, so this PR addresses this issue

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
