### PR TITLE
[#IOPLT-274] Add Support for AKS LTS on elastic module

### DIFF
--- a/elastic_stack/versions.tf
+++ b/elastic_stack/versions.tf
@@ -12,8 +12,8 @@ terraform {
     }
 
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "1.14.0"
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
     }
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- Change kubectl terraform provider on elastic_stack
<!--- Describe your changes in detail -->

### Motivation and context
Starting from update on https://medium.com/@danieljimgarcia/dont-use-the-terraform-kubernetes-manifest-resource-6c7ff4fe629a
we must change kubectl providers because old provider is not supported on kubernetes 1.27
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
