### PR TITLE
feat: Migrate property for AppService and Function App [EC-39]

### DIFF
--- a/app_service/README.md
+++ b/app_service/README.md
@@ -56,7 +56,7 @@ Of course, the values listed above may change in the future, so please check whi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.39.0, <= 3.71.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.39.0, <= 3.84.0 |
 
 ## Modules
 

--- a/app_service/README.md
+++ b/app_service/README.md
@@ -86,6 +86,7 @@ No modules.
 | <a name="input_dotnet_version"></a> [dotnet\_version](#input\_dotnet\_version) | n/a | `string` | `null` | no |
 | <a name="input_ftps_state"></a> [ftps\_state](#input\_ftps\_state) | (Optional) Enable FTPS connection ( Default: Disabled ) | `string` | `"Disabled"` | no |
 | <a name="input_go_version"></a> [go\_version](#input\_go\_version) | n/a | `string` | `null` | no |
+| <a name="input_health_check_maxpingfailures"></a> [health\_check\_maxpingfailures](#input\_health\_check\_maxpingfailures) | Max ping failures allowed | `number` | `null` | no |
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | (Optional) The health check path to be pinged by App Service. | `string` | `null` | no |
 | <a name="input_https_only"></a> [https\_only](#input\_https\_only) | (Optional) Can the App Service only be accessed via HTTPS? Defaults to true. | `bool` | `true` | no |
 | <a name="input_java_server"></a> [java\_server](#input\_java\_server) | n/a | `string` | `null` | no |

--- a/app_service/main.tf
+++ b/app_service/main.tf
@@ -63,7 +63,8 @@ resource "azurerm_linux_web_app" "this" {
     ftps_state             = var.ftps_state
     vnet_route_all_enabled = var.subnet_id == null ? false : true
 
-    health_check_path = var.health_check_path != null ? var.health_check_path : null
+    health_check_path                 = var.health_check_path != null ? var.health_check_path : null
+    health_check_eviction_time_in_min = var.health_check_path != null ? var.health_check_maxpingfailures : null
 
     http2_enabled = true
 

--- a/app_service/variables.tf
+++ b/app_service/variables.tf
@@ -126,6 +126,17 @@ variable "health_check_path" {
   default     = null
 }
 
+variable "health_check_maxpingfailures" {
+  type        = number
+  description = "Max ping failures allowed"
+  default     = null
+
+  validation {
+    condition     = var.health_check_maxpingfailures == null ? true : (var.health_check_maxpingfailures >= 2 && var.health_check_maxpingfailures <= 10)
+    error_message = "Possible values are null or a number between 2 and 10"
+  }
+}
+
 variable "allowed_subnets" {
   type        = list(string)
   description = "(Optional) List of subnet allowed to call the appserver endpoint."

--- a/app_service/versions.tf
+++ b/app_service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.39.0, <= 3.71.0"
+      version = ">= 3.39.0, <= 3.84.0"
     }
   }
 }

--- a/function_app/README.md
+++ b/function_app/README.md
@@ -211,7 +211,7 @@ See [Generic resource migration](../.docs/MIGRATION_GUIDE_GENERIC_RESOURCES.md)
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.30.0, <= 3.71.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.30.0, <= 3.84.0 |
 
 ## Modules
 

--- a/function_app/main.tf
+++ b/function_app/main.tf
@@ -231,15 +231,16 @@ resource "azurerm_linux_function_app" "this" {
   client_certificate_mode    = var.client_certificate_mode
 
   site_config {
-    minimum_tls_version       = "1.2"
-    ftps_state                = "Disabled"
-    http2_enabled             = true
-    always_on                 = var.always_on
-    pre_warmed_instance_count = var.pre_warmed_instance_count
-    vnet_route_all_enabled    = var.subnet_id == null ? false : true
-    use_32_bit_worker         = var.use_32_bit_worker_process
-    application_insights_key  = var.application_insights_instrumentation_key
-    health_check_path         = var.health_check_path
+    minimum_tls_version               = "1.2"
+    ftps_state                        = "Disabled"
+    http2_enabled                     = true
+    always_on                         = var.always_on
+    pre_warmed_instance_count         = var.pre_warmed_instance_count
+    vnet_route_all_enabled            = var.subnet_id == null ? false : true
+    use_32_bit_worker                 = var.use_32_bit_worker_process
+    application_insights_key          = var.application_insights_instrumentation_key
+    health_check_path                 = var.health_check_path
+    health_check_eviction_time_in_min = var.health_check_path != null ? var.health_check_maxpingfailures : null
 
     dynamic "app_service_logs" {
       for_each = var.app_service_logs != null ? [var.app_service_logs] : []
@@ -298,8 +299,6 @@ resource "azurerm_linux_function_app" "this" {
     {
       # No downtime on slots swap
       WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG = 1
-      # default value for health_check_path, override it in var.app_settings if needed
-      WEBSITE_HEALTHCHECK_MAXPINGFAILURES = var.health_check_path != null ? var.health_check_maxpingfailures : null
       # https://docs.microsoft.com/en-us/samples/azure-samples/azure-functions-private-endpoints/connect-to-private-endpoints-with-azure-functions/
       SLOT_TASK_HUBNAME        = "ProductionTaskHub"
       WEBSITE_RUN_FROM_PACKAGE = 1

--- a/function_app/variables.tf
+++ b/function_app/variables.tf
@@ -179,13 +179,17 @@ variable "health_check_path" {
   type        = string
   description = "Path which will be checked for this function app health."
   default     = null
-
 }
 
 variable "health_check_maxpingfailures" {
   type        = number
   description = "Max ping failures allowed"
   default     = 10
+
+  validation {
+    condition     = var.health_check_maxpingfailures == null ? true : (var.health_check_maxpingfailures >= 2 && var.health_check_maxpingfailures <= 10)
+    error_message = "Possible values are null or a number between 2 and 10"
+  }
 }
 
 variable "export_keys" {

--- a/function_app/versions.tf
+++ b/function_app/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.30.0, <= 3.71.0"
+      version = ">= 3.30.0, <= 3.84.0"
     }
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Replace `WEBSITE_HEALTHCHECK_MAXPINGFAILURES` with `health_check_eviction_time_in_min`.
Add constraints for values from 2 to 10 minutes. Null is allowed.
Extend the maximum azurerm version to the latest (3.84.0)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Starting from azurerm v3.63, it's not possible anymore to use the app setting `WEBSITE_HEALTHCHECK_MAXPINGFAILURES` to set up the probe threshold. This PR shifts from the use of the app setting to the new property `health_check_eviction_time_in_min`. Internally, it does the same thing (=creating an app setting)

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
