### PR TITLE
feat: Update naming convention for managed identities' resource group name [EC-41]

### DIFF
--- a/github_federated_identity/README.md
+++ b/github_federated_identity/README.md
@@ -19,9 +19,9 @@ For debugging purposes, you might be useful module's output containing the brand
 
 ## Design
 
-To avoid the creation of tons of similar identities, each subscription should have a single resource group which contains two user managed identities, one for Continuos Integration and the other for Continuos Delivery/Deployment workflows. Each user managed identity is federated with one or more repositories and with one or more GitHub environments.
+To avoid the creation of tons of similar identities, each subscription should have a single resource group which contains a maximum of two user managed identities per repository, one for Continuos Integration and the other for Continuos Delivery/Deployment workflows. Each user managed identity is federated with one or more repositories and one or more GitHub environments.
 
-This module expects to find an existing resource group named `<prefix>-<shortenv>-<domain>-identity-rg`. Then, it creates a [user managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp) in it using the naming convention `<prefix>-<shortenv>-<domain>-github-<idrole>-identity`; the `idrole` value is obtained from the input variable `identity_role` and can be either `ci` or `cd`. Finally, the variable `github_federations` defines the list of the repositories and GitHub environments to create a federation with. The federation output name uses the form `<prefix>-<shortenv>-<domain>-${var.app_name}-github"-<repo>-<scope>-<subject>`.
+This module expects to find an existing resource group named `<prefix>-<shortenv>-identity-rg`. Then, it creates a [user managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp) in it using the naming convention `<prefix>-<shortenv>-<domain>-github-<idrole>-identity`; the `idrole` value is obtained from the input variable `identity_role` and can be either `ci` or `cd`. Finally, the variable `github_federations` defines the list of the repositories and GitHub environments to create a federation with. The federation output name uses the form `<prefix>-<shortenv>-<domain>-${var.app_name}-github"-<repo>-<scope>-<subject>`.
 
 > Consume this module once for each identity. You are likely to invoke the module twice then, one time for CI identity and one time for CD identity.
 
@@ -41,7 +41,7 @@ The Terraform template in `./tests` folder can be used as an example or a templa
 
 ### Requirements
 
-As stated in the [Design](#design) section, you must define a new resource group before invoking this module. Look at the `./tests` to get an example. Remember: the resource group name should match the naming convention `<prefix>-<shortenv>-<domain>-identity-rg`, where `domain` can be empty.
+As stated in the [Design](#design) section, you must define a new resource group before invoking this module. Look at the `./tests` to get an example. Remember: the resource group name should match the naming convention `<prefix>-<shortenv>-identity-rg`.
 
 If the resource group is not found, an exception is thrown.
 

--- a/github_federated_identity/locals.tf
+++ b/github_federated_identity/locals.tf
@@ -1,7 +1,7 @@
 locals {
   name = var.domain == "" ? "${var.prefix}-${var.env_short}" : "${var.prefix}-${var.env_short}-${var.domain}"
 
-  resource_group_name = "${local.name}-identity-rg"
+  resource_group_name = "${var.prefix}-${var.env_short}-identity-rg"
   identity_name       = "${local.name}-github-${var.identity_role}-identity"
   federation_prefix   = var.app_name == "" ? "${local.name}-github" : "${local.name}-${var.app_name}-github"
 }

--- a/github_federated_identity/tests/resources.tf
+++ b/github_federated_identity/tests/resources.tf
@@ -2,7 +2,7 @@
 
 # resource group name should follow the convention specified in README.md file
 resource "azurerm_resource_group" "identity_rg" {
-  name     = var.domain == "" ? "${var.prefix}-${local.env_short}-identity-rg" : "${var.prefix}-${local.env_short}-${var.domain}-identity-rg"
+  name     = "${var.prefix}-${local.env_short}-identity-rg"
   location = var.location
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Update the naming convention from `<project>-<env_short>-<domain>-identity-rg` to `<project>-<env_short>-identity-rg`.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
It does worth to have a single resource group per stream, having all managed identities in it. Separation by domain is done at managed identity level (e.g. `<prefix>-<shortenv>-<domain>-github-<idrole>-identity`)

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [X] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
