### PR TITLE
fix: Update naming convention for github managed identities - [EC-59]

### DIFF
--- a/github_federated_identity/README.md
+++ b/github_federated_identity/README.md
@@ -19,9 +19,7 @@ For debugging purposes, you might be useful module's output containing the brand
 
 ## Design
 
-To avoid the creation of tons of similar identities, each subscription should have a single resource group which contains a maximum of two user managed identities per repository, one for Continuos Integration and the other for Continuos Delivery/Deployment workflows. Each user managed identity is federated with one or more repositories and one or more GitHub environments.
-
-This module expects to find an existing resource group named `<prefix>-<shortenv>-identity-rg`. Then, it creates a [user managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp) in it using the naming convention `<prefix>-<shortenv>-<domain>-github-<idrole>-identity`; the `idrole` value is obtained from the input variable `identity_role` and can be either `ci` or `cd`. Finally, the variable `github_federations` defines the list of the repositories and GitHub environments to create a federation with. The federation output name uses the form `<prefix>-<shortenv>-<domain>-${var.app_name}-github"-<repo>-<scope>-<subject>`.
+This module expects to find an existing resource group named `<prefix>-<shortenv>-identity-rg`. Then, it creates a [user managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp) in it using the naming convention `<prefix>-<shortenv>-<domain>-[<app_name>]-github-<idrole>-identity`; the `idrole` value is obtained from the input variable `identity_role` and can be either `ci` or `cd`. Finally, the variable `github_federations` defines the list of the repositories and GitHub environments to create a federation with. The federation output name uses the form `<prefix>-<shortenv>-<domain>-github"-<repo>-<scope>-<subject>`.
 
 > Consume this module once for each identity. You are likely to invoke the module twice then, one time for CI identity and one time for CD identity.
 

--- a/github_federated_identity/locals.tf
+++ b/github_federated_identity/locals.tf
@@ -2,6 +2,6 @@ locals {
   name = var.domain == "" ? "${var.prefix}-${var.env_short}" : "${var.prefix}-${var.env_short}-${var.domain}"
 
   resource_group_name = "${var.prefix}-${var.env_short}-identity-rg"
-  identity_name       = "${local.name}-github-${var.identity_role}-identity"
-  federation_prefix   = var.app_name == "" ? "${local.name}-github" : "${local.name}-${var.app_name}-github"
+  identity_name       = var.app_name == "" ? "${local.name}-github-${var.identity_role}-identity" : "${local.name}-${var.app_name}-github-${var.identity_role}-identity"
+  federation_prefix   = "${local.name}-github"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
The variable `app_name` is now used to set the managed identity name instead of the federation credentials.
Docs updated according to this change

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A new scenario (io-sign) came with a new need. Since it is a monorepo, multiple apps and or domains need multiple managed identities (2+), each of them with different permissions and scopes.

With the current naming convention there is no way to have 2+ managed identities per repo, since the current module version is designed as it.

However, this could be considered as a non-breaking change since io-sign is the first monorepo to integrate this module.

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
