### PR TITLE
fix: Do not set function app property auth_settings to avoid not real drift

### DIFF
--- a/function_app/main.tf
+++ b/function_app/main.tf
@@ -287,11 +287,6 @@ resource "azurerm_linux_function_app" "this" {
         allowed_origins = cors.value.allowed_origins
       }
     }
-
-  }
-
-  auth_settings {
-    enabled = false
   }
 
   # https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
`auth_settings` property is not explicitly set anymore 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

`terraform plan` output is always the following:

![image](https://github.com/pagopa/terraform-azurerm-v3/assets/7879858/087ab99e-502f-4816-92d3-f706b5c6db98)

It's just noise. It is caused by the module's assignment removed in this PR.

[Default is `false`](https://registry.terraform.io/providers/hashicorp/azurerm/3.84.0/docs/resources/linux_function_app#auth_settings), so values don't change

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
