### PR TITLE
fix: Update GitHub runner base image to 2.312

### DIFF
--- a/container_app_job_gh_runner/README.md
+++ b/container_app_job_gh_runner/README.md
@@ -101,7 +101,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_container"></a> [container](#input\_container) | Job Container configuration | <pre>object({<br>    cpu    = number<br>    memory = string<br>    image  = string<br>  })</pre> | <pre>{<br>  "cpu": 0.5,<br>  "image": "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:a4ddc89b5a65c367442b024c4ac0edbfdcb363a731727b88853b3df0dcd2a711",<br>  "memory": "1Gi"<br>}</pre> | no |
+| <a name="input_container"></a> [container](#input\_container) | Job Container configuration | <pre>object({<br>    cpu    = number<br>    memory = string<br>    image  = string<br>  })</pre> | <pre>{<br>  "cpu": 0.5,<br>  "image": "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:8834704c1697dd26c1a1f867626b2d5206c8787dcbb1ffd25c9de77f21c101b2",<br>  "memory": "1Gi"<br>}</pre> | no |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Short environment prefix | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Container App Environment configuration (Log Analytics Workspace) | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
 | <a name="input_job"></a> [job](#input\_job) | Container App job configuration | <pre>object({<br>    name                 = string<br>    repo_owner           = optional(string, "pagopa")<br>    repo                 = string<br>    polling_interval     = optional(number, 30)<br>    scale_max_executions = optional(number, 5)<br>  })</pre> | n/a | yes |

--- a/container_app_job_gh_runner/variables.tf
+++ b/container_app_job_gh_runner/variables.tf
@@ -54,7 +54,7 @@ variable "container" {
   default = {
     cpu    = 0.5
     memory = "1Gi"
-    image  = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:a4ddc89b5a65c367442b024c4ac0edbfdcb363a731727b88853b3df0dcd2a711"
+    image  = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:8834704c1697dd26c1a1f867626b2d5206c8787dcbb1ffd25c9de77f21c101b2"
   }
 
   description = "Job Container configuration"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Update base image for Container App Job used to run GitHub runners

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A new image is available

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
