### PR TITLE
fix: Apim plan

### DIFF
--- a/api_management/README.md
+++ b/api_management/README.md
@@ -177,8 +177,8 @@ No modules.
 | <a name="input_public_ip_address_id"></a> [public\_ip\_address\_id](#input\_public\_ip\_address\_id) | A Public Ip resource ID | `string` | `null` | no |
 | <a name="input_publisher_email"></a> [publisher\_email](#input\_publisher\_email) | The email of publisher/company. | `string` | n/a | yes |
 | <a name="input_publisher_name"></a> [publisher\_name](#input\_publisher\_name) | The name of publisher/company. | `string` | n/a | yes |
-| <a name="input_redis_cache_id"></a> [redis\_cache\_id](#input\_redis\_cache\_id) | The resource ID of the Cache for Redis. | `string` | n/a | yes |
-| <a name="input_redis_connection_string"></a> [redis\_connection\_string](#input\_redis\_connection\_string) | Connection string for redis external cache | `string` | `null` | no |
+| <a name="input_redis_cache_id"></a> [redis\_cache\_id](#input\_redis\_cache\_id) | The resource ID of the Cache for Redis. Set `use_redis_cache` = true tuse this value | `string` | n/a | yes |
+| <a name="input_redis_connection_string"></a> [redis\_connection\_string](#input\_redis\_connection\_string) | Connection string for redis external cache. Set `use_redis_cache` = true tuse this value | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_sec_log_analytics_workspace_id"></a> [sec\_log\_analytics\_workspace\_id](#input\_sec\_log\_analytics\_workspace\_id) | Log analytics workspace security (it should be in a different subscription). | `string` | `null` | no |
 | <a name="input_sec_storage_id"></a> [sec\_storage\_id](#input\_sec\_storage\_id) | Storage Account security (it should be in a different subscription). | `string` | `null` | no |
@@ -187,6 +187,7 @@ No modules.
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | A string consisting of two parts separated by an underscore(\_). The first part is the name, valid values include: Consumption, Developer, Basic, Standard and Premium. The second part is the capacity (e.g. the number of deployed units of the sku), which must be a positive integer (e.g. Developer\_1). | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The id of the subnet that will be used for the API Management. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
+| <a name="input_use_redis_cache"></a> [use\_redis\_cache](#input\_use\_redis\_cache) | (Optional) if true, enables redis caching | `bool` | `false` | no |
 | <a name="input_virtual_network_type"></a> [virtual\_network\_type](#input\_virtual\_network\_type) | The type of virtual network you want to use, valid values include: None, External, Internal | `string` | `null` | no |
 | <a name="input_xml_content"></a> [xml\_content](#input\_xml\_content) | Xml content for all api policy | `string` | `null` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | List of availability zones | `list(string)` | `[]` | no |

--- a/api_management/README.md
+++ b/api_management/README.md
@@ -177,8 +177,9 @@ No modules.
 | <a name="input_public_ip_address_id"></a> [public\_ip\_address\_id](#input\_public\_ip\_address\_id) | A Public Ip resource ID | `string` | `null` | no |
 | <a name="input_publisher_email"></a> [publisher\_email](#input\_publisher\_email) | The email of publisher/company. | `string` | n/a | yes |
 | <a name="input_publisher_name"></a> [publisher\_name](#input\_publisher\_name) | The name of publisher/company. | `string` | n/a | yes |
-| <a name="input_redis_cache_id"></a> [redis\_cache\_id](#input\_redis\_cache\_id) | The resource ID of the Cache for Redis. Set `use_redis_cache` = true tuse this value | `string` | n/a | yes |
-| <a name="input_redis_connection_string"></a> [redis\_connection\_string](#input\_redis\_connection\_string) | Connection string for redis external cache. Set `use_redis_cache` = true tuse this value | `string` | `null` | no |
+| <a name="input_redis_cache_enabled"></a> [redis\_cache\_enabled](#input\_redis\_cache\_enabled) | (Optional) if true, enables redis caching | `bool` | `false` | no |
+| <a name="input_redis_cache_id"></a> [redis\_cache\_id](#input\_redis\_cache\_id) | The resource ID of the Cache for Redis. Set `redis_cache_enabled` = true tuse this value | `string` | n/a | yes |
+| <a name="input_redis_connection_string"></a> [redis\_connection\_string](#input\_redis\_connection\_string) | Connection string for redis external cache. Set `redis_cache_enabled` = true tuse this value | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_sec_log_analytics_workspace_id"></a> [sec\_log\_analytics\_workspace\_id](#input\_sec\_log\_analytics\_workspace\_id) | Log analytics workspace security (it should be in a different subscription). | `string` | `null` | no |
 | <a name="input_sec_storage_id"></a> [sec\_storage\_id](#input\_sec\_storage\_id) | Storage Account security (it should be in a different subscription). | `string` | `null` | no |
@@ -187,7 +188,6 @@ No modules.
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | A string consisting of two parts separated by an underscore(\_). The first part is the name, valid values include: Consumption, Developer, Basic, Standard and Premium. The second part is the capacity (e.g. the number of deployed units of the sku), which must be a positive integer (e.g. Developer\_1). | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The id of the subnet that will be used for the API Management. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
-| <a name="input_use_redis_cache"></a> [use\_redis\_cache](#input\_use\_redis\_cache) | (Optional) if true, enables redis caching | `bool` | `false` | no |
 | <a name="input_virtual_network_type"></a> [virtual\_network\_type](#input\_virtual\_network\_type) | The type of virtual network you want to use, valid values include: None, External, Internal | `string` | `null` | no |
 | <a name="input_xml_content"></a> [xml\_content](#input\_xml\_content) | Xml content for all api policy | `string` | `null` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | List of availability zones | `list(string)` | `[]` | no |

--- a/api_management/main.tf
+++ b/api_management/main.tf
@@ -306,7 +306,7 @@ resource "azurerm_monitor_metric_alert" "this" {
 # 🧺 REDIS
 #
 resource "azurerm_api_management_redis_cache" "this" {
-  count = var.use_redis_cache ? 1 : 0
+  count = var.redis_cache_enabled ? 1 : 0
 
   name              = format("%s-redis", var.name)
   api_management_id = azurerm_api_management.this.id

--- a/api_management/main.tf
+++ b/api_management/main.tf
@@ -306,7 +306,7 @@ resource "azurerm_monitor_metric_alert" "this" {
 # 🧺 REDIS
 #
 resource "azurerm_api_management_redis_cache" "this" {
-  count = var.redis_connection_string != null ? 1 : 0
+  count = var.use_redis_cache ? 1 : 0
 
   name              = format("%s-redis", var.name)
   api_management_id = azurerm_api_management.this.id

--- a/api_management/variables.tf
+++ b/api_management/variables.tf
@@ -277,13 +277,13 @@ variable "action" {
 
 variable "redis_connection_string" {
   type        = string
-  description = "Connection string for redis external cache. Set `use_redis_cache` = true tuse this value"
+  description = "Connection string for redis external cache. Set `redis_cache_enabled` = true tuse this value"
   default     = null
 }
 
 variable "redis_cache_id" {
   type        = string
-  description = "The resource ID of the Cache for Redis. Set `use_redis_cache` = true tuse this value"
+  description = "The resource ID of the Cache for Redis. Set `redis_cache_enabled` = true tuse this value"
 }
 
 variable "alerts_enabled" {
@@ -356,7 +356,7 @@ variable "public_ip_address_id" {
   description = "A Public Ip resource ID"
 }
 
-variable "use_redis_cache" {
+variable "redis_cache_enabled" {
   type        = bool
   description = "(Optional) if true, enables redis caching"
   default     = false

--- a/api_management/variables.tf
+++ b/api_management/variables.tf
@@ -277,13 +277,13 @@ variable "action" {
 
 variable "redis_connection_string" {
   type        = string
-  description = "Connection string for redis external cache"
+  description = "Connection string for redis external cache. Set `use_redis_cache` = true tuse this value"
   default     = null
 }
 
 variable "redis_cache_id" {
   type        = string
-  description = "The resource ID of the Cache for Redis."
+  description = "The resource ID of the Cache for Redis. Set `use_redis_cache` = true tuse this value"
 }
 
 variable "alerts_enabled" {
@@ -354,4 +354,10 @@ variable "public_ip_address_id" {
   type        = string
   default     = null
   description = "A Public Ip resource ID"
+}
+
+variable "use_redis_cache" {
+  type        = bool
+  description = "(Optional) if true, enables redis caching"
+  default     = false
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

added new boolean variable to enable redis cache usage on apim

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

relying on the connection string to determine the count of the redis cache resource caused failure in the plan phase if the redis connection string depends on the apply of the plan

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
