### PR TITLE
feat: Update azdo image module

### DIFF
--- a/azure_devops_agent_custom_image/README.md
+++ b/azure_devops_agent_custom_image/README.md
@@ -88,17 +88,18 @@ No modules.
 | <a name="input_base_image_publisher"></a> [base\_image\_publisher](#input\_base\_image\_publisher) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"Canonical"` | no |
 | <a name="input_base_image_sku"></a> [base\_image\_sku](#input\_base\_image\_sku) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"22_04-lts-gen2"` | no |
 | <a name="input_base_image_version"></a> [base\_image\_version](#input\_base\_image\_version) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"latest"` | no |
-| <a name="input_build_rg_name"></a> [build\_rg\_name](#input\_build\_rg\_name) | (Optional) Packer build temporary resource group name | `string` | `"tmp-packer-build"` | no |
-| <a name="input_build_subnet_name"></a> [build\_subnet\_name](#input\_build\_subnet\_name) | (Required) Packer build subnet name | `string` | n/a | yes |
-| <a name="input_build_vnet_name"></a> [build\_vnet\_name](#input\_build\_vnet\_name) | (Required) Packer build vnet name | `string` | n/a | yes |
-| <a name="input_build_vnet_rg_name"></a> [build\_vnet\_rg\_name](#input\_build\_vnet\_rg\_name) | (Required) Packer build vnet rg name | `string` | n/a | yes |
+| <a name="input_build_rg_name"></a> [build\_rg\_name](#input\_build\_rg\_name) | (Optional) Packer build temporary resource group name | `string` | `"tmp-packer-azdo-image-build"` | no |
+| <a name="input_build_subnet_name"></a> [build\_subnet\_name](#input\_build\_subnet\_name) | (Optional) Packer build subnet name | `string` | `null` | no |
+| <a name="input_build_vnet_name"></a> [build\_vnet\_name](#input\_build\_vnet\_name) | (Optional) Packer build vnet name | `string` | `null` | no |
+| <a name="input_build_vnet_rg_name"></a> [build\_vnet\_rg\_name](#input\_build\_vnet\_rg\_name) | (Optional) Packer build vnet rg name | `string` | `null` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | (Required) name assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | (Required) Version assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | (Required) prefix used in resource creation | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the Resource Group in which the custom image will be created | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) Azure subscription id | `string` | n/a | yes |
-| <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B1s"` | no |
+| <a name="input_use_external_vnet"></a> [use\_external\_vnet](#input\_use\_external\_vnet) | Enable the use of a custom vnet | `bool` | `false` | no |
+| <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B2ms"` | no |
 
 ## Outputs
 

--- a/azure_devops_agent_custom_image/README.md
+++ b/azure_devops_agent_custom_image/README.md
@@ -40,9 +40,7 @@ module "azdoa_custom_image" {
   build_vnet_name     = "my-vnet-name" 
   build_subnet_name   = "my-subnet-name"  
   build_vnet_rg_name  = "vnet-rg-name"
-
   
-  tags = var.tags
 }
 
 ```

--- a/azure_devops_agent_custom_image/README.md
+++ b/azure_devops_agent_custom_image/README.md
@@ -54,7 +54,10 @@ module "azdoa_custom_image" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.101.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | <= 3.2.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | <= 3.6.0 |
 
 ## Modules
 
@@ -91,14 +94,12 @@ No modules.
 | <a name="input_build_subnet_name"></a> [build\_subnet\_name](#input\_build\_subnet\_name) | (Required) Packer build subnet name | `string` | n/a | yes |
 | <a name="input_build_vnet_name"></a> [build\_vnet\_name](#input\_build\_vnet\_name) | (Required) Packer build vnet name | `string` | n/a | yes |
 | <a name="input_build_vnet_rg_name"></a> [build\_vnet\_rg\_name](#input\_build\_vnet\_rg\_name) | (Required) Packer build vnet rg name | `string` | n/a | yes |
-| <a name="input_force_replacement"></a> [force\_replacement](#input\_force\_replacement) | (Optional) Wheather if the image should be deleted and recreated even if already existing | `bool` | `false` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | (Required) name assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | (Required) Version assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | (Required) prefix used in resource creation | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the Resource Group in which the custom image will be created | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) Azure subscription id | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
 | <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B1s"` | no |
 
 ## Outputs

--- a/azure_devops_agent_custom_image/main.tf
+++ b/azure_devops_agent_custom_image/main.tf
@@ -104,24 +104,26 @@ resource "null_resource" "build_packer_image" {
   provisioner "local-exec" {
     working_dir = "${path.module}/packer"
     command     = <<EOT
-    packer init . && \
-    packer build \
-    -var "subscription=${var.subscription_id}" \
-    -var "target_resource_group_name=${var.resource_group_name}" \
-    -var "base_image_publisher=${var.base_image_publisher}" \
-    -var "base_image_offer=${var.base_image_offer}" \
-    -var "base_image_sku=${var.base_image_sku}" \
-    -var "base_image_version=${var.base_image_version}" \
-    -var "vm_sku=${var.vm_sku}" \
-    -var "target_image_name=${local.target_image_name}" \
-    -var "location=${var.location}" \
-    -var "client_id=${azuread_application.packer_application.application_id}" \
-    -var "client_secret=${azuread_application_password.velero_application_password.value}" \
-    -var "build_rg_name=${azurerm_resource_group.build_rg.name}" \
-    -var "build_vnet_name=${var.build_vnet_name}" \
-    -var "build_vnet_subnet_name=${var.build_subnet_name}" \
-    -var "build_vnet_rg_name=${var.build_vnet_rg_name}" \
-    .
+    {
+      packer init . && \
+      packer build \
+      -var "subscription=${var.subscription_id}" \
+      -var "target_resource_group_name=${var.resource_group_name}" \
+      -var "base_image_publisher=${var.base_image_publisher}" \
+      -var "base_image_offer=${var.base_image_offer}" \
+      -var "base_image_sku=${var.base_image_sku}" \
+      -var "base_image_version=${var.base_image_version}" \
+      -var "vm_sku=${var.vm_sku}" \
+      -var "target_image_name=${local.target_image_name}" \
+      -var "location=${var.location}" \
+      -var "client_id=${azuread_application.packer_application.application_id}" \
+      -var "client_secret=${azuread_application_password.velero_application_password.value}" \
+      -var "build_rg_name=${azurerm_resource_group.build_rg.name}" \
+      -var "build_vnet_name=${var.build_vnet_name}" \
+      -var "build_vnet_subnet_name=${var.build_subnet_name}" \
+      -var "build_vnet_rg_name=${var.build_vnet_rg_name}" \
+      .
+    } >> /tmp/packer-azdo.log
     EOT
   }
 

--- a/azure_devops_agent_custom_image/main.tf
+++ b/azure_devops_agent_custom_image/main.tf
@@ -14,6 +14,7 @@ data "azurerm_virtual_network" "build_vnet" {
   resource_group_name = var.build_vnet_rg_name
 }
 
+#--------------- RESOURCES ------------------------
 
 resource "random_id" "rg_randomizer" {
   keepers = {
@@ -71,7 +72,6 @@ resource "azurerm_role_assignment" "packer_sp_build_vnet_role" {
   role_definition_name = "Network Contributor"
   principal_id         = azuread_service_principal.packer_sp.object_id
 }
-
 
 resource "null_resource" "build_packer_image" {
 

--- a/azure_devops_agent_custom_image/main.tf
+++ b/azure_devops_agent_custom_image/main.tf
@@ -10,7 +10,7 @@ data "azurerm_resource_group" "target_resource_group" {
 }
 
 data "azurerm_virtual_network" "build_vnet" {
-  count = !var.use_external_vnet ? 1 : 0
+  count = var.use_external_vnet ? 1 : 0
   name                = var.build_vnet_name
   resource_group_name = var.build_vnet_rg_name
 }
@@ -68,7 +68,7 @@ resource "azurerm_role_assignment" "packer_sp_build_rg_role" {
 }
 
 resource "azurerm_role_assignment" "packer_sp_build_vnet_role" {
-  count = !var.use_external_vnet ? 1 : 0
+  count = var.use_external_vnet ? 1 : 0
 
   scope                = data.azurerm_virtual_network.build_vnet[0].id
   role_definition_name = "Network Contributor"

--- a/azure_devops_agent_custom_image/main.tf
+++ b/azure_devops_agent_custom_image/main.tf
@@ -10,6 +10,7 @@ data "azurerm_resource_group" "target_resource_group" {
 }
 
 data "azurerm_virtual_network" "build_vnet" {
+  count = var.custom_vnet_enabled ? 1 : 0
   name                = var.build_vnet_name
   resource_group_name = var.build_vnet_rg_name
 }
@@ -68,7 +69,7 @@ resource "azurerm_role_assignment" "packer_sp_build_rg_role" {
 }
 
 resource "azurerm_role_assignment" "packer_sp_build_vnet_role" {
-  scope                = data.azurerm_virtual_network.build_vnet.id
+  scope                = data.azurerm_virtual_network.build_vnet[0].id
   role_definition_name = "Network Contributor"
   principal_id         = azuread_service_principal.packer_sp.object_id
 }

--- a/azure_devops_agent_custom_image/main.tf
+++ b/azure_devops_agent_custom_image/main.tf
@@ -10,7 +10,7 @@ data "azurerm_resource_group" "target_resource_group" {
 }
 
 data "azurerm_virtual_network" "build_vnet" {
-  count = var.use_external_vnet ? 1 : 0
+  count               = var.use_external_vnet ? 1 : 0
   name                = var.build_vnet_name
   resource_group_name = var.build_vnet_rg_name
 }
@@ -87,7 +87,7 @@ resource "null_resource" "build_packer_image" {
     vm_sku                     = var.vm_sku
     target_image_name          = local.target_image_name
     location                   = var.location
-    use_external_vnet = var.use_external_vnet
+    use_external_vnet          = var.use_external_vnet
   }
 
   depends_on = [
@@ -123,9 +123,9 @@ resource "null_resource" "build_packer_image" {
       -var "client_id=${azuread_application.packer_application.application_id}" \
       -var "client_secret=${azuread_application_password.velero_application_password.value}" \
       -var "build_rg_name=${azurerm_resource_group.build_rg.name}" \
-      ${var.use_external_vnet ? "-var 'build_vnet_name=${var.build_vnet_name}'" : "" } \
-      ${var.use_external_vnet ? "-var 'build_vnet_subnet_name=${var.build_subnet_name}'" : "" } \
-      ${var.use_external_vnet ? "-var 'build_vnet_rg_name=${var.build_vnet_rg_name}'" : "" } \
+      ${var.use_external_vnet ? "-var 'build_vnet_name=${var.build_vnet_name}'" : ""} \
+      ${var.use_external_vnet ? "-var 'build_vnet_subnet_name=${var.build_subnet_name}'" : ""} \
+      ${var.use_external_vnet ? "-var 'build_vnet_rg_name=${var.build_vnet_rg_name}'" : ""} \
       .
 
     } >> /tmp/packer-azdo.log

--- a/azure_devops_agent_custom_image/packer/script-config.sh
+++ b/azure_devops_agent_custom_image/packer/script-config.sh
@@ -24,12 +24,12 @@ curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 check_command "az"
 
 # install helm
-az acr helm install-cli -y --client-version 3.12.0
+az acr helm install-cli -y --client-version 3.14.2
 
 check_command "helm"
 
 # install kubectl
-az aks install-cli --client-version 1.25.10 --kubelogin-version 0.0.29
+az aks install-cli --client-version 1.27.12 --kubelogin-version 0.1.3
 
 check_command "kubectl"
 
@@ -42,7 +42,7 @@ echo \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 apt-get -y update
-apt-get -y install  python3-pip
+apt-get -y install python3-pip
 
 check_command "python3"
 
@@ -52,7 +52,7 @@ apt-get -y --allow-unauthenticated install docker-ce docker-ce-cli containerd.io
 check_command "docker"
 
 # install YQ from https://github.com/mikefarah/yq#install
-YQ_VERSION="v4.33.3"
+YQ_VERSION="v4.43.1"
 YQ_BINARY="yq_linux_amd64"
 wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz -O - |\
   tar xz && mv ${YQ_BINARY} /usr/bin/yq
@@ -60,14 +60,14 @@ wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY
 check_command "yq"
 
 # install SOPS from https://github.com/mozilla/sops
-SOPS_VERSION="3.7.3"
+SOPS_VERSION="3.8.1"
 wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops_${SOPS_VERSION}_amd64.deb"
 apt install -y "$PWD/sops_${SOPS_VERSION}_amd64.deb"
 
 check_command "sops"
 
 # install Velero
-VELERO_VERSION=v1.11.1
+VELERO_VERSION=v1.13.2
 wget https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-amd64.tar.gz && \
 tar -zxvf velero-${VELERO_VERSION}-linux-amd64.tar.gz && \
 sudo mv velero-${VELERO_VERSION}-linux-amd64/velero /usr/bin/velero

--- a/azure_devops_agent_custom_image/packer/variables.pkr.hcl
+++ b/azure_devops_agent_custom_image/packer/variables.pkr.hcl
@@ -37,7 +37,7 @@ variable "base_image_version" {
 variable "vm_sku" {
   type        = string
   description = "(Optional) Size of VMs in the scale set. Default to Standard_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info."
-  default     = "Standard_B1s"
+  default     = "Standard_B2ms"
 }
 
 variable "target_image_name" {
@@ -61,15 +61,21 @@ variable "build_rg_name" {
   description = "(Required) temporary build resource group name"
 }
 
+#
+# CUSTOM VNET
+#
 variable "build_vnet_name" {
   type        = string
-  description = "(Required) temporary build resource group name"
+  description = "(Optional) temporary build vnet name"
+  default = null
 }
 variable "build_vnet_subnet_name" {
   type        = string
-  description = "(Required) temporary build resource group name"
+  description = "(Optional) temporary build subnet name"
+  default = null
 }
 variable "build_vnet_rg_name" {
   type        = string
-  description = "(Required) temporary build resource group name"
+  description = "(Optional) temporary build vnet resource group name"
+  default = null
 }

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -30,12 +30,6 @@ variable "image_version" {
   description = "(Required) Version assigned to the generated image. Note that the pair <image_name, image_version> must be unique and not already existing"
 }
 
-variable "force_replacement" {
-  type        = bool
-  description = "(Optional) Wheather if the image should be deleted and recreated even if already existing"
-  default     = false
-}
-
 variable "base_image_offer" {
   type        = string
   default     = "0001-com-ubuntu-server-jammy"
@@ -57,10 +51,6 @@ variable "vm_sku" {
   type        = string
   description = "(Optional) Size of VMs in the scale set. Default to Standard_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info."
   default     = "Standard_B1s"
-}
-
-variable "tags" {
-  type = map(any)
 }
 
 variable "prefix" {

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -64,17 +64,23 @@ variable "build_rg_name" {
   default     = "tmp-packer-azdo-image-build"
 }
 
+#
+# Custom VNET
+#
 variable "build_vnet_name" {
   type        = string
-  description = "(Required) Packer build vnet name"
+  description = "(Optional) Packer build vnet name"
+  default = "null"
 }
 
 variable "build_subnet_name" {
   type        = string
-  description = "(Required) Packer build subnet name"
+  description = "(Optional) Packer build subnet name"
+  default = null
 }
 
 variable "build_vnet_rg_name" {
   type        = string
-  description = "(Required) Packer build vnet rg name"
+  description = "(Optional) Packer build vnet rg name"
+  default = null
 }

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -67,6 +67,12 @@ variable "build_rg_name" {
 #
 # Custom VNET
 #
+variable "custom_vnet_enabled" {
+type = bool
+  description = "Enable the use of a custom vnet"
+  default = false
+}
+
 variable "build_vnet_name" {
   type        = string
   description = "(Optional) Packer build vnet name"

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -67,7 +67,7 @@ variable "build_rg_name" {
 #
 # Custom VNET
 #
-variable "custom_vnet_enabled" {
+variable "use_external_vnet" {
 type = bool
   description = "Enable the use of a custom vnet"
   default = false

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -68,25 +68,25 @@ variable "build_rg_name" {
 # Custom VNET
 #
 variable "use_external_vnet" {
-type = bool
+  type        = bool
   description = "Enable the use of a custom vnet"
-  default = false
+  default     = false
 }
 
 variable "build_vnet_name" {
   type        = string
   description = "(Optional) Packer build vnet name"
-  default = null
+  default     = null
 }
 
 variable "build_subnet_name" {
   type        = string
   description = "(Optional) Packer build subnet name"
-  default = null
+  default     = null
 }
 
 variable "build_vnet_rg_name" {
   type        = string
   description = "(Optional) Packer build vnet rg name"
-  default = null
+  default     = null
 }

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -76,7 +76,7 @@ type = bool
 variable "build_vnet_name" {
   type        = string
   description = "(Optional) Packer build vnet name"
-  default = "null"
+  default = null
 }
 
 variable "build_subnet_name" {

--- a/azure_devops_agent_custom_image/variables.tf
+++ b/azure_devops_agent_custom_image/variables.tf
@@ -50,7 +50,7 @@ variable "base_image_version" {
 variable "vm_sku" {
   type        = string
   description = "(Optional) Size of VMs in the scale set. Default to Standard_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info."
-  default     = "Standard_B1s"
+  default     = "Standard_B2ms"
 }
 
 variable "prefix" {
@@ -61,7 +61,7 @@ variable "prefix" {
 variable "build_rg_name" {
   type        = string
   description = "(Optional) Packer build temporary resource group name"
-  default     = "tmp-packer-build"
+  default     = "tmp-packer-azdo-image-build"
 }
 
 variable "build_vnet_name" {

--- a/azure_devops_agent_custom_image/versions.tf
+++ b/azure_devops_agent_custom_image/versions.tf
@@ -6,5 +6,17 @@ terraform {
       source  = "hashicorp/null"
       version = "<= 3.2.1"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "<= 2.47.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<= 3.101.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "<= 3.6.0"
+    }
   }
 }

--- a/dns_forwarder_vm_image/README.md
+++ b/dns_forwarder_vm_image/README.md
@@ -87,14 +87,12 @@ No modules.
 | <a name="input_base_image_sku"></a> [base\_image\_sku](#input\_base\_image\_sku) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"22_04-lts-gen2"` | no |
 | <a name="input_base_image_version"></a> [base\_image\_version](#input\_base\_image\_version) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"latest"` | no |
 | <a name="input_build_rg_name"></a> [build\_rg\_name](#input\_build\_rg\_name) | (Optional) Packer build temporary resource group name | `string` | `"tmp-packer-dnsforwarder-build"` | no |
-| <a name="input_force_replacement"></a> [force\_replacement](#input\_force\_replacement) | (Optional) Wheather if the image should be deleted and recreated even if already existing | `bool` | `false` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | (Required) name assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | (Required) Version assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | (Required) prefix used in resource creation | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the Resource Group in which the custom image will be created | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) Azure subscription id | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
 | <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B2s"` | no |
 
 ## Outputs

--- a/dns_forwarder_vm_image/README.md
+++ b/dns_forwarder_vm_image/README.md
@@ -52,7 +52,10 @@ module "dns_forwarder_image" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.97.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | <= 3.2.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | <= 3.6.0 |
 
 ## Modules
 

--- a/dns_forwarder_vm_image/README.md
+++ b/dns_forwarder_vm_image/README.md
@@ -86,14 +86,14 @@ No modules.
 | <a name="input_base_image_publisher"></a> [base\_image\_publisher](#input\_base\_image\_publisher) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"Canonical"` | no |
 | <a name="input_base_image_sku"></a> [base\_image\_sku](#input\_base\_image\_sku) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"22_04-lts-gen2"` | no |
 | <a name="input_base_image_version"></a> [base\_image\_version](#input\_base\_image\_version) | (Optional) - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set#source_image_reference | `string` | `"latest"` | no |
-| <a name="input_build_rg_name"></a> [build\_rg\_name](#input\_build\_rg\_name) | (Optional) Packer build temporary resource group name | `string` | `"tmp-packer-dnsforwarder-build"` | no |
+| <a name="input_build_rg_name"></a> [build\_rg\_name](#input\_build\_rg\_name) | (Optional) Packer build temporary resource group name | `string` | `"tmp-packer-dnsforwarder-image-build"` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | (Required) name assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | (Required) Version assigned to the generated image. Note that the pair <image\_name, image\_version> must be unique and not already existing | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | (Required) prefix used in resource creation | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the Resource Group in which the custom image will be created | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) Azure subscription id | `string` | n/a | yes |
-| <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B2s"` | no |
+| <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B2ms"` | no |
 
 ## Outputs
 

--- a/dns_forwarder_vm_image/variables.tf
+++ b/dns_forwarder_vm_image/variables.tf
@@ -37,12 +37,6 @@ variable "image_version" {
   description = "(Required) Version assigned to the generated image. Note that the pair <image_name, image_version> must be unique and not already existing"
 }
 
-variable "force_replacement" {
-  type        = bool
-  description = "(Optional) Wheather if the image should be deleted and recreated even if already existing"
-  default     = false
-}
-
 variable "base_image_offer" {
   type        = string
   default     = "0001-com-ubuntu-server-jammy"
@@ -64,10 +58,6 @@ variable "vm_sku" {
   type        = string
   description = "(Optional) Size of VMs in the scale set. Default to Standard_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info."
   default     = "Standard_B2s"
-}
-
-variable "tags" {
-  type = map(any)
 }
 
 variable "prefix" {

--- a/dns_forwarder_vm_image/variables.tf
+++ b/dns_forwarder_vm_image/variables.tf
@@ -57,7 +57,7 @@ variable "base_image_version" {
 variable "vm_sku" {
   type        = string
   description = "(Optional) Size of VMs in the scale set. Default to Standard_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info."
-  default     = "Standard_B2s"
+  default     = "Standard_B2ms"
 }
 
 variable "prefix" {
@@ -68,5 +68,5 @@ variable "prefix" {
 variable "build_rg_name" {
   type        = string
   description = "(Optional) Packer build temporary resource group name"
-  default     = "tmp-packer-dnsforwarder-build"
+  default     = "tmp-packer-dnsforwarder-image-build"
 }

--- a/dns_forwarder_vm_image/versions.tf
+++ b/dns_forwarder_vm_image/versions.tf
@@ -6,5 +6,17 @@ terraform {
       source  = "hashicorp/null"
       version = "<= 3.2.1"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "<= 2.47.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<= 3.97.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "<= 3.6.0"
+    }
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Updated script packer for ubuntu, to have kubectl 1.27 and kubelogin 0.1.0+
- external vnet for packer now is optional, to avoid problem with vpn
- use_external_vnet feature flag to use vnet from outside
- updated vm sku to B2ms to decrease time for build

### Motivation and context

Allow to choose if use external vnet or internal vnet temp to create the vm image

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
