### PR TITLE
fix: Storage module -> enable_resource_advanced_threat_protection variable removed

### DIFF
--- a/api_management/README.md
+++ b/api_management/README.md
@@ -33,7 +33,7 @@ resource "azurerm_resource_group" "rg_api" {
 
 # APIM subnet
 module "apim_snet" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.11.0"
+  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                 = "${local.program}-apim-snet"
   resource_group_name  = data.azurerm_resource_group.rg_vnet.name
   virtual_network_name = data.azurerm_virtual_network.vnet.name
@@ -48,7 +48,7 @@ module "apim_snet" {
 ###########################
 
 module "apim" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management?ref=v3.11.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management?ref=v8.8.0"
 
   name = "${local.program}-apim"
 

--- a/api_management_api/README.md
+++ b/api_management_api/README.md
@@ -30,7 +30,7 @@ locals {
 # }
 
 module "apim_devopslab_webapp_python_alpha_api_v1" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_api?ref=v3.11.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_api?ref=v8.8.0"
 
   name                  = local.apim_devopslab_webapp_python_alpha_api.api_name
   api_management_name   = module.apim.name

--- a/api_management_product/README.md
+++ b/api_management_product/README.md
@@ -10,7 +10,7 @@ This module allow the creation of api management product, and associate to a gro
 
 ```ts
 module "apim_product_devopslab" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v3.11.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v8.8.0"
 
   product_id   = "devopslab"
   display_name = "DevOpsLab Program"

--- a/app_gateway/README.md
+++ b/app_gateway/README.md
@@ -42,7 +42,7 @@ resource "azurerm_key_vault_access_policy" "app_gateway_policy" {
 
 # Subnet to host the application gateway
 module "appgateway_snet" {
-  source               = "git::https://github.com/pagopa/azurerm.git//subnet?ref=v2.1.21"
+  source               = "git::https://github.com/pagopa/azurerm.git//subnet?ref=v8.8.0"
 
   name                 = "${local.project}-appgateway-snet"
   address_prefixes     = var.cidr_subnet_appgateway
@@ -86,7 +86,7 @@ module "appgateway_snet" {
 
   # Subnet to host the application gateway
   module "appgateway_snet" {
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.11.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
 
     name                 = "${local.program}-appgateway-snet"
     address_prefixes     = var.cidr_subnet_appgateway
@@ -99,7 +99,7 @@ module "appgateway_snet" {
   module "app_gw" {
     count = var.app_gateway_is_enabled ? 1 : 0
 
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_gateway?ref=v3.11.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//app_gateway?ref=v8.8.0"
 
     name                = "${local.program}-app-gw"
     resource_group_name = data.azurerm_resource_group.rg_vnet.name

--- a/application_insights_standard_web_test/README.md
+++ b/application_insights_standard_web_test/README.md
@@ -6,7 +6,7 @@ This module create an alert for a http(s) webservice
 
 ```hcl
 module "webservice_monitor_01" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//application_insights_standard_web_test?ref=vX.X.X"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//application_insights_standard_web_test?ref=v8.8.0"
   
 
   https_endpoint                         = "https://api.dev.platform.pagopa.it"

--- a/application_insights_web_test_preview/README.md
+++ b/application_insights_web_test_preview/README.md
@@ -20,7 +20,7 @@ locals {
 
 module "web_test_availability_alert_rules_for_api" {
   for_each = { for v in local.test_urls : v.host => v if v != null }
-  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//application_insights_web_test_preview?ref=v3.15.0"
+  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//application_insights_web_test_preview?ref=v8.8.0"
 
   subscription_id                   = data.azurerm_subscription.current.subscription_id
   name                              = "${each.value.host}-test-avail"

--- a/azure_devops_agent/README.md
+++ b/azure_devops_agent/README.md
@@ -17,7 +17,7 @@ resource "azurerm_resource_group" "azdo_rg" {
 
 # with custom image (previously built. check the module `azure_devops_agent_custom_image` for more details)
 module "module "azdoa_vmss_li" {" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=<version>"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v8.8.0"
   count               = var.enable_azdoa ? 1 : 0
   name                = "${local.azuredevops_agent_vm_name}"
   resource_group_name = azurerm_resource_group.azdo_rg[0].name
@@ -33,7 +33,7 @@ module "module "azdoa_vmss_li" {" {
 
 # with default image
 module "module "azdoa_vmss_li" {" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=<version>"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v8.8.0"
   count               = var.enable_azdoa ? 1 : 0
   name                = "${local.azuredevops_agent_vm_name}"
   resource_group_name = azurerm_resource_group.azdo_rg[0].name
@@ -47,7 +47,7 @@ module "module "azdoa_vmss_li" {" {
 
 # with standard image
 module "module "azdoa_vmss_li" {" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=<version>"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent?ref=v8.8.0"
   count               = var.enable_azdoa ? 1 : 0
   name                = "${local.azuredevops_agent_vm_name}"
   resource_group_name = azurerm_resource_group.azdo_rg[0].name

--- a/azure_devops_agent_custom_image/README.md
+++ b/azure_devops_agent_custom_image/README.md
@@ -29,7 +29,7 @@ data "azurerm_resource_group" "resource_group" {
 }
 
 module "azdoa_custom_image" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent_custom_image?ref=<version>"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//azure_devops_agent_custom_image?ref=v8.8.0"
   resource_group_name = data.azurerm_resource_group.resource_group.name
   location            = var.location
   image_name          = "my_image_name"

--- a/cdn/README.md
+++ b/cdn/README.md
@@ -99,7 +99,7 @@ During the apply there will be 1 changed and 1 destroy related to storage see [s
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cdn_storage_account"></a> [cdn\_storage\_account](#module\_cdn\_storage\_account) | github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.76.0 |
+| <a name="module_cdn_storage_account"></a> [cdn\_storage\_account](#module\_cdn\_storage\_account) | github.com/pagopa/terraform-azurerm-v3.git//storage_account | v8.8.0 |
 
 ## Resources
 

--- a/cdn/README.md
+++ b/cdn/README.md
@@ -6,6 +6,10 @@ This module allow the creation of a CDN endpoint and CDN profile
 
 ![This is an image](./docs/module-arch.drawio.png)
 
+## Logical breaking changes
+
+* `resource_advanced_threat_protection_enabled` was removed -> use `advanced_threat_protection_enabled`
+
 ## How to use it
 
 ```ts

--- a/cdn/README.md
+++ b/cdn/README.md
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "devopslab_cdn_rg" {
 ### Frontend resources
 #tfsec:ignore:azure-storage-queue-services-logging-enabled:exp:2022-05-01 # already ignored, maybe a bug in tfsec
 module "devopslab_cdn" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cdn?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cdn?ref=v8.8.0"
 
   name                  = "diego"
   prefix                = local.product

--- a/cdn/README.md
+++ b/cdn/README.md
@@ -149,7 +149,6 @@ During the apply there will be 1 changed and 1 destroy related to storage see [s
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |
 | <a name="input_querystring_caching_behaviour"></a> [querystring\_caching\_behaviour](#input\_querystring\_caching\_behaviour) | n/a | `string` | `"IgnoreQueryString"` | no |
-| <a name="input_resource_advanced_threat_protection_enabled"></a> [resource\_advanced\_threat\_protection\_enabled](#input\_resource\_advanced\_threat\_protection\_enabled) | Enabled azurerm\_advanced\_threat\_protection resource | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_storage_access_tier"></a> [storage\_access\_tier](#input\_storage\_access\_tier) | n/a | `string` | `"Hot"` | no |
 | <a name="input_storage_account_kind"></a> [storage\_account\_kind](#input\_storage\_account\_kind) | n/a | `string` | `"StorageV2"` | no |

--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -7,7 +7,7 @@ locals {
  **/
 module "cdn_storage_account" {
 
-  source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v7.76.0"
+  source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v8.8.0"
 
   name = replace("${var.prefix}-${var.name}-sa", "-", "")
 

--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -22,7 +22,6 @@ module "cdn_storage_account" {
   public_network_access_enabled   = true
 
   advanced_threat_protection                 = var.advanced_threat_protection_enabled
-  enable_resource_advanced_threat_protection = var.resource_advanced_threat_protection_enabled
 
   index_document     = var.index_document
   error_404_document = var.error_404_document

--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -21,7 +21,7 @@ module "cdn_storage_account" {
   allow_nested_items_to_be_public = var.storage_account_nested_items_public
   public_network_access_enabled   = true
 
-  advanced_threat_protection                 = var.advanced_threat_protection_enabled
+  advanced_threat_protection = var.advanced_threat_protection_enabled
 
   index_document     = var.index_document
   error_404_document = var.error_404_document

--- a/cdn/tests/resources.tf
+++ b/cdn/tests/resources.tf
@@ -32,6 +32,9 @@ resource "azurerm_key_vault" "this" {
   tags = var.tags
 }
 
+#
+# CDN
+#
 module "cdn" {
   source = "../../cdn"
 

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -362,12 +362,6 @@ variable "advanced_threat_protection_enabled" {
   default = false
 }
 
-variable "resource_advanced_threat_protection_enabled" {
-  type        = bool
-  description = "Enabled azurerm_advanced_threat_protection resource"
-  default     = true
-}
-
 variable "storage_account_nested_items_public" {
   type        = bool
   default     = true

--- a/cert_mounter/README.md
+++ b/cert_mounter/README.md
@@ -7,7 +7,7 @@ This module deploys the cert mounter blueprint in the target namespace, creating
 ```hcl
 
 module "cert_mounter" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cert_mounter?ref=<version>"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cert_mounter?ref=v8.8.0"
   namespace           = var.domain
   certificate_name    = "${var.aks_cluster_domain_name}-${var.domain}-internal-${var.env}-cstar-pagopa-it" #name of the certificate stored in the given kv
   kv_name             = data.azurerm_key_vault.kv.name

--- a/cosmosdb_account/README.md
+++ b/cosmosdb_account/README.md
@@ -12,7 +12,7 @@ This module allow the setup of a cosmos db account
 
 ```ts
 module "cosmos_mongo" {
-  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_account?ref=v3.15.0"
+  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_account?ref=v8.8.0"
   name     = "${local.project}-cosmos-mongo"
   location = var.location
   domain   = var.domain
@@ -69,7 +69,7 @@ module "cosmos_mongo" {
 
 ```ts
 module "cosmos_core" {
-  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_account?ref=v3.15.0"
+  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_account?ref=v8.8.0"
   name     = "${local.project}-cosmos-core"
   location = var.location
   domain   = var.domain

--- a/cosmosdb_mongodb_collection/README.md
+++ b/cosmosdb_mongodb_collection/README.md
@@ -10,7 +10,7 @@ This module allow the creation of a collection inside a MongoDB database
 
 ```ts
 module "mongdb_collection_name" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_mongodb_collection?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_mongodb_collection?ref=v8.8.0"
 
   name                = "collectionName"
   resource_group_name = azurerm_resource_group.cosmos_mongo_rg[0].name

--- a/cosmosdb_sql_container/README.md
+++ b/cosmosdb_sql_container/README.md
@@ -32,7 +32,7 @@ locals {
 
 
 module "core_cosmosdb_containers" {
-  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_container?ref=v3.15.0"
+  source   = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_container?ref=v8.8.0"
   for_each = { for c in local.core_cosmosdb_containers : c.name => c }
 
   name                = each.value.name

--- a/cosmosdb_sql_database/README.md
+++ b/cosmosdb_sql_database/README.md
@@ -38,7 +38,7 @@ resource "azurerm_cosmosdb_mongo_database" "mongo_db" {
 ```ts
 ## Database
 module "core_cosmos_db" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_database?ref=v3.15.0"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_sql_database?ref=v8.8.0"
   name                = "db"
   resource_group_name = azurerm_resource_group.cosmos_rg[0].name
   account_name        = module.cosmos_core.name

--- a/data_indexer/README.md
+++ b/data_indexer/README.md
@@ -19,7 +19,7 @@ Use the example Terraform template, saved in `./tests`, to test this module and 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_internal_storage_account"></a> [internal\_storage\_account](#module\_internal\_storage\_account) | github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.76.0 |
+| <a name="module_internal_storage_account"></a> [internal\_storage\_account](#module\_internal\_storage\_account) | github.com/pagopa/terraform-azurerm-v3.git//storage_account | v8.8.0 |
 
 ## Resources
 

--- a/data_indexer/storage.tf
+++ b/data_indexer/storage.tf
@@ -1,6 +1,6 @@
 
 module "internal_storage_account" {
-  source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v7.76.0"
+  source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v8.8.0"
 
   name                                       = "${replace(var.name, "-", "")}dist"
   account_kind                               = var.internal_storage.account_kind

--- a/data_indexer/storage.tf
+++ b/data_indexer/storage.tf
@@ -9,7 +9,6 @@ module "internal_storage_account" {
   access_tier                                = var.internal_storage.access_tier
   resource_group_name                        = azurerm_resource_group.this.name
   location                                   = var.location
-  enable_resource_advanced_threat_protection = false
   advanced_threat_protection                 = false
   public_network_access_enabled              = false
 
@@ -17,13 +16,13 @@ module "internal_storage_account" {
 }
 
 resource "azurerm_private_endpoint" "blob" {
-  name                = format("%s-blob-endpoint", module.internal_storage_account.name)
+  name                = "${module.internal_storage_account.name}-blob-endpoint"
   location            = var.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = var.internal_storage.private_endpoint_subnet_id
 
   private_service_connection {
-    name                           = format("%s-blob", module.internal_storage_account.name)
+    name                           = "${module.internal_storage_account.name}-blob"
     private_connection_resource_id = module.internal_storage_account.id
     is_manual_connection           = false
     subresource_names              = ["blob"]
@@ -38,13 +37,13 @@ resource "azurerm_private_endpoint" "blob" {
 }
 
 resource "azurerm_private_endpoint" "queue" {
-  name                = format("%s-queue-endpoint", module.internal_storage_account.name)
+  name                = "${module.internal_storage_account.name}-queue-endpoint"
   location            = var.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = var.internal_storage.private_endpoint_subnet_id
 
   private_service_connection {
-    name                           = format("%s-queue", module.internal_storage_account.name)
+    name                           = "${module.internal_storage_account.name}-queue"
     private_connection_resource_id = module.internal_storage_account.id
     is_manual_connection           = false
     subresource_names              = ["queue"]
@@ -59,13 +58,13 @@ resource "azurerm_private_endpoint" "queue" {
 }
 
 resource "azurerm_private_endpoint" "table" {
-  name                = format("%s-table-endpoint", module.internal_storage_account.name)
+  name                = "${module.internal_storage_account.name}-table-endpoint"
   location            = var.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = var.internal_storage.private_endpoint_subnet_id
 
   private_service_connection {
-    name                           = format("%s-table", module.internal_storage_account.name)
+    name                           = "${module.internal_storage_account.name}-table"
     private_connection_resource_id = module.internal_storage_account.id
     is_manual_connection           = false
     subresource_names              = ["table"]

--- a/data_indexer/storage.tf
+++ b/data_indexer/storage.tf
@@ -2,15 +2,15 @@
 module "internal_storage_account" {
   source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v8.8.0"
 
-  name                                       = "${replace(var.name, "-", "")}dist"
-  account_kind                               = var.internal_storage.account_kind
-  account_tier                               = var.internal_storage.account_tier
-  account_replication_type                   = var.internal_storage.account_replication_type
-  access_tier                                = var.internal_storage.access_tier
-  resource_group_name                        = azurerm_resource_group.this.name
-  location                                   = var.location
-  advanced_threat_protection                 = false
-  public_network_access_enabled              = false
+  name                          = "${replace(var.name, "-", "")}dist"
+  account_kind                  = var.internal_storage.account_kind
+  account_tier                  = var.internal_storage.account_tier
+  account_replication_type      = var.internal_storage.account_replication_type
+  access_tier                   = var.internal_storage.access_tier
+  resource_group_name           = azurerm_resource_group.this.name
+  location                      = var.location
+  advanced_threat_protection    = false
+  public_network_access_enabled = false
 
   tags = var.tags
 }

--- a/dns_forwarder/README.md
+++ b/dns_forwarder/README.md
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "dns_forwarder" {
 module "dns_forwarder_snet" {
   count = var.dns_forwarder_enabled ? 1 : 0
 
-  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                                      = "${local.project}-dnsforwarder-snet"
   address_prefixes                          = var.cidr_subnet_dnsforwarder
   resource_group_name                       = azurerm_resource_group.rg_vnet.name
@@ -38,7 +38,7 @@ module "dns_forwarder_snet" {
 }
 
 module "dns_forwarder" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder?ref=v8.8.0"
 
   name                = "${local.project}-dns-forwarder"
   location            = var.location

--- a/dns_forwarder_lb_vmss/README.md
+++ b/dns_forwarder_lb_vmss/README.md
@@ -13,7 +13,7 @@ To secure the scale set, a Network Security Group has been added, allowing inbou
 
 module "dns_forwarder" {
 
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder_lb_vmss?ref=7.48.0"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder_lb_vmss?ref=v8.8.0"
 
   name                 = var.prefix
   virtual_network_name = azurerm_virtual_network.vnet.name

--- a/dns_forwarder_lb_vmss/README.md
+++ b/dns_forwarder_lb_vmss/README.md
@@ -43,10 +43,10 @@ module "dns_forwarder" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_load_balancer"></a> [load\_balancer](#module\_load\_balancer) | git::https://github.com/pagopa/terraform-azurerm-v3.git//load_balancer | v7.76.0 |
-| <a name="module_subnet_load_balancer"></a> [subnet\_load\_balancer](#module\_subnet\_load\_balancer) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.76.0 |
-| <a name="module_subnet_vmss"></a> [subnet\_vmss](#module\_subnet\_vmss) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v7.76.0 |
-| <a name="module_vmss"></a> [vmss](#module\_vmss) | git::https://github.com/pagopa/terraform-azurerm-v3.git//vm_scale_set | v7.76.0 |
+| <a name="module_load_balancer"></a> [load\_balancer](#module\_load\_balancer) | git::https://github.com/pagopa/terraform-azurerm-v3.git//load_balancer | v8.8.0 |
+| <a name="module_subnet_load_balancer"></a> [subnet\_load\_balancer](#module\_subnet\_load\_balancer) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.8.0 |
+| <a name="module_subnet_vmss"></a> [subnet\_vmss](#module\_subnet\_vmss) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.8.0 |
+| <a name="module_vmss"></a> [vmss](#module\_vmss) | git::https://github.com/pagopa/terraform-azurerm-v3.git//vm_scale_set | v8.8.0 |
 
 ## Resources
 

--- a/dns_forwarder_lb_vmss/main.tf
+++ b/dns_forwarder_lb_vmss/main.tf
@@ -15,7 +15,7 @@ locals {
 #
 
 module "subnet_vmss" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.76.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   count  = var.subnet_vmss_id != null ? 0 : 1
 
   name                 = "${local.prefix}-vmss-snet"
@@ -29,7 +29,7 @@ module "subnet_vmss" {
 #
 
 module "subnet_load_balancer" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.76.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   count  = var.subnet_lb_id != null ? 0 : 1
 
   name                 = "${local.prefix}-lb-snet"
@@ -100,7 +100,7 @@ resource "azurerm_subnet_network_security_group_association" "vmss" {
 #
 
 module "load_balancer" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//load_balancer?ref=v7.76.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//load_balancer?ref=v8.8.0"
 
   name                = "${local.prefix}-internal"
   resource_group_name = var.resource_group_name
@@ -150,7 +150,7 @@ module "load_balancer" {
 #
 
 module "vmss" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//vm_scale_set?ref=v7.76.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//vm_scale_set?ref=v8.8.0"
 
   name                                   = local.prefix
   resource_group_name                    = var.resource_group_name

--- a/dns_forwarder_scale_set_vm/README.md
+++ b/dns_forwarder_scale_set_vm/README.md
@@ -8,7 +8,7 @@ The dns forwarder vm expose port 53 in TCP/UDP for azure vpn
 
 ```hcl
 module "dns_forwarder_backup_snet" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.11.0"
+  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   count                = var.dns_forwarder_backup_is_enabled.uat || var.dns_forwarder_backup_is_enabled.prod ? 1 : 0
   name                 = "${local.project}-dns-forwarder-backup-snet"
   address_prefixes     = var.cidr_subnet_dns_forwarder_backup
@@ -19,7 +19,7 @@ module "dns_forwarder_backup_snet" {
 # with default image
 module "dns_forwarder_backup_vmss_li" {
 
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder_scale_set_vm?ref=dns-forwarder-scaleset-vm"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder_scale_set_vm?ref=v8.8.0"
   count               = var.dns_forwarder_backup_is_enabled.uat || var.dns_forwarder_backup_is_enabled.prod ? 1 : 0
   name                = local.dns_forwarder_backup_name
   resource_group_name = data.azurerm_resource_group.rg_vnet_core.name

--- a/dns_forwarder_vm_image/README.md
+++ b/dns_forwarder_vm_image/README.md
@@ -32,7 +32,7 @@ Example:
 
 ```hcl
 module "dns_forwarder_image" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder_vm_image?ref=dns-forwarder-scaleset-vm"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//dns_forwarder_vm_image?ref=v8.8.0"
   resource_group_name = data.azurerm_resource_group.rg_vnet_core.name
   location            = var.location
   image_name          = "${local.product}-dns-forwarder-ubuntu2204-image"

--- a/function_app/README.md
+++ b/function_app/README.md
@@ -55,7 +55,7 @@ E.g.
 **Docker**
 ```hcl
 module "authorizer_function_app" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v6.6.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v8.8.0"
 
   resource_group_name = data.azurerm_resource_group.shared_rg.name
   name                = "${local.project}-authorizer-fn"

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -15,7 +15,7 @@ resource "azurerm_resource_group" "load_test" {
 }
 
 module "grafana_managed" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//grafana?ref=feature/new_output_grafana"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//grafana?ref=v8.8.0"
 
   name = "${local.product}-grafana"
 

--- a/grafana_dashboard/README.md
+++ b/grafana_dashboard/README.md
@@ -9,7 +9,7 @@ This module allow the creation of Grafana Dashboard to all "grafana = yes" tagge
 ```ts
 module "auto_dashboard" {
 
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//grafana_dashboard?ref=xxx"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//grafana_dashboard?ref=v8.8.0"
 
   grafana_url = azurerm_dashboard_grafana.grafana_dashboard.endpoint
   grafana_api_key = "GRAFANA_SERVICE_ACCOUNT_TOKEN"

--- a/jwt_keys/README.md
+++ b/jwt_keys/README.md
@@ -6,7 +6,7 @@ Module that allows the creation of an jwt keys.
 
 ```ts
 module "my_jwt" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//jwt_keys?ref=v3.4.1"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//jwt_keys?ref=v8.8.0"
 
   jwt_name         = "my-jwt"
   key_vault_id     = azurerm_key_vault.kv.id

--- a/key_vault/README.md
+++ b/key_vault/README.md
@@ -6,7 +6,7 @@ This module allow the creation of a key vault
 
 ```ts
 module "key_vault_domain" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault?ref=v8.8.0"
 
   name                       = "${local.product}-${var.domain}-kv"
   location                   = azurerm_resource_group.sec_rg_domain.location

--- a/key_vault_secrets_query/README.md
+++ b/key_vault_secrets_query/README.md
@@ -6,7 +6,7 @@ This module simplified how to make the queries into a kv
 
 ```ts
 module "key_vault_secrets_query" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v8.8.0"
 
   resource_group = local.key_vault_resource_group
   key_vault_name = local.key_vault_name

--- a/kubernetes_cluster/README.md
+++ b/kubernetes_cluster/README.md
@@ -494,7 +494,7 @@ keda_helm_version        = "2.6.2"
   }
 
   module "aks" {
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=v3.15.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=v8.8.0"
 
     count = var.aks_enabled ? 1 : 0
 

--- a/kubernetes_cluster_udr/README.md
+++ b/kubernetes_cluster_udr/README.md
@@ -492,7 +492,7 @@ keda_helm_version        = "2.6.2"
   }
 
   module "aks" {
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=v3.15.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=v8.8.0"
 
     count = var.aks_enabled ? 1 : 0
 

--- a/kubernetes_cluster_velero/01_main.tf
+++ b/kubernetes_cluster_velero/01_main.tf
@@ -8,7 +8,7 @@ data "azurerm_kubernetes_cluster" "aks_cluster" {
 }
 
 module "velero_storage_account" {
-  source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v7.76.0"
+  source = "github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v8.8.0"
 
   name                            = "${local.sa_prefix}velerosa"
   account_kind                    = var.storage_account_kind

--- a/kubernetes_cluster_velero/README.md
+++ b/kubernetes_cluster_velero/README.md
@@ -60,7 +60,7 @@ This is achievable using the utility script `k8setup.sh` included in the aks-set
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_velero_storage_account"></a> [velero\_storage\_account](#module\_velero\_storage\_account) | github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.76.0 |
+| <a name="module_velero_storage_account"></a> [velero\_storage\_account](#module\_velero\_storage\_account) | github.com/pagopa/terraform-azurerm-v3.git//storage_account | v8.8.0 |
 
 ## Resources
 

--- a/kubernetes_cluster_velero/README.md
+++ b/kubernetes_cluster_velero/README.md
@@ -15,7 +15,7 @@ This is achievable using the utility script `k8setup.sh` included in the aks-set
   }
  
   module "velero" {
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster_velero?ref=<version>"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster_velero?ref=v8.8.0"
     
     # required
     backup_storage_container_name = "velero-backup"

--- a/kubernetes_pod_identity/README.md
+++ b/kubernetes_pod_identity/README.md
@@ -10,7 +10,7 @@ Module that allows the creation of a pod identity. Check <https://docs.microsoft
 
 ```ts
 module "domain_pod_identity" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity?ref=v8.8.0"
 
   resource_group_name = local.aks_resource_group_name
   location            = var.location

--- a/kubernetes_prometheus_install/README.md
+++ b/kubernetes_prometheus_install/README.md
@@ -10,7 +10,7 @@ Change the `storage_class_name` varaible in order to use a Zone Redundant storag
 
 ```hcl
 module "aks_prometheus_install" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_prometheus_install?ref=<version>"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_prometheus_install?ref=v8.8.0"
   
   prometheus_namespace = "monitoring"
   storage_class_name = "default-zrs" #example of ZRS storage class created by kubernetes_storage_class

--- a/kubernetes_service_account/README.md
+++ b/kubernetes_service_account/README.md
@@ -8,7 +8,7 @@ This module creates a service account and its related secrets
 
 ```hcl
 module "kubernetes_service_account" {
-  source  = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_service_account?ref=<version>"
+  source  = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_service_account?ref=v8.8.0"
   name = "azure-devops"
   namespace = local.system_domain_namespace
 }

--- a/kubernetes_storage_class/README.md
+++ b/kubernetes_storage_class/README.md
@@ -18,7 +18,7 @@ This module creates a series of storage class with ZRS redundancy to be used in 
 
 ```hcl
 module "aks_storage_class" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_storage_class?ref=<version>"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_storage_class?ref=v8.8.0"
   
 }
 ```

--- a/kubernetes_velero_backup/README.md
+++ b/kubernetes_velero_backup/README.md
@@ -12,7 +12,7 @@ This module requires Velero to be installed; check module `kubernetes_cluster_ve
 
 ```hcl
 module "aks_namespace_backup" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_velero_backup?ref=<version>"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_velero_backup?ref=v8.8.0"
   
   # required
   aks_cluster_name = module.aks.name

--- a/letsencrypt_credential/README.md
+++ b/letsencrypt_credential/README.md
@@ -14,7 +14,7 @@ TBD
 
 ```ts
 module "letsencrypt_diego" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//letsencrypt_credential?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//letsencrypt_credential?ref=v8.8.0"
 
   prefix            = "dvopla"
   env               = "d"

--- a/monitoring_function/01_main.tf
+++ b/monitoring_function/01_main.tf
@@ -12,7 +12,7 @@ data "azurerm_application_insights" "app_insight" {
 }
 
 module "synthetic_monitoring_storage_account" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v7.76.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v8.8.0"
 
   name                            = "${local.sa_prefix}synthmon"
   account_kind                    = var.storage_account_settings.kind

--- a/monitoring_function/README.md
+++ b/monitoring_function/README.md
@@ -33,7 +33,7 @@ This module creates a table storage to save the provided monitoring configuratio
 ```hcl
 
 module "synthetic_monitoring_subnet" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v7.39.0"
+  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                 = "${var.prefix}-synthetic-monitoring-snet"
   address_prefixes     = ["10.1.182.0/23"]
   resource_group_name  = "dvopla-d-vnet-rg"
@@ -63,7 +63,7 @@ resource "azurerm_container_app_environment" "container_app_environment" {
 
 # basic
 module "monitoring_function" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//monitoring_function?ref=5cdc24a"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//monitoring_function?ref=v8.8.0"
 
   location = "northeurope"
   prefix = "dvopla-d"
@@ -106,7 +106,7 @@ module "monitoring_function" {
 
 # with private endpoint and custom alert configuration
 module "monitoring_function" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//monitoring_function?ref=5cdc24a"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//monitoring_function?ref=v8.8.0"
 
   location = "northeurope"
   prefix = "dvopla-d"

--- a/monitoring_function/README.md
+++ b/monitoring_function/README.md
@@ -176,7 +176,7 @@ module "monitoring_function" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_synthetic_monitoring_storage_account"></a> [synthetic\_monitoring\_storage\_account](#module\_synthetic\_monitoring\_storage\_account) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v7.76.0 |
+| <a name="module_synthetic_monitoring_storage_account"></a> [synthetic\_monitoring\_storage\_account](#module\_synthetic\_monitoring\_storage\_account) | git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account | v8.8.0 |
 
 ## Resources
 

--- a/postgres_flexible_server/README.md
+++ b/postgres_flexible_server/README.md
@@ -94,7 +94,7 @@ variable "pgflex_public_metric_alerts" {
 
   # Postgres Flexible Server subnet
   module "postgres_flexible_snet" {
-    source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+    source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
     name                                      = "${local.program}-pgres-flexible-snet"
     address_prefixes                          = var.cidr_subnet_flex_dbms
     resource_group_name                       = data.azurerm_resource_group.rg_vnet.name
@@ -140,7 +140,7 @@ variable "pgflex_public_metric_alerts" {
 
     count = var.pgflex_private_config.enabled ? 1 : 0
 
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server?ref=v3.15.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server?ref=v8.8.0"
 
     name                = "${local.program}-private-pgflex"
     location            = azurerm_resource_group.postgres_dbs.location
@@ -200,7 +200,7 @@ variable "pgflex_public_metric_alerts" {
 
     count = var.pgflex_public_config.enabled ? 1 : 0
 
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server?ref=v3.15.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server?ref=v8.8.0"
 
     name                = "${local.program}-public-pgflex"
     location            = azurerm_resource_group.postgres_dbs.location
@@ -254,7 +254,7 @@ module "postgres_flexible_server_private" {
 
     count = var.pgflex_private_config.enabled ? 1 : 0
 
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server?ref=v3.15.0"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server?ref=v8.8.0"
 
     name                = "${local.program}-private-pgflex"
     location            = azurerm_resource_group.postgres_dbs.location

--- a/postgres_flexible_server_replica/README.md
+++ b/postgres_flexible_server_replica/README.md
@@ -70,7 +70,7 @@ variable "main_server_additional_alerts" {
   # Postgres Flexible Server subnet
   module "postgres_flexible_snet_replica" {
     count = var.geo_replica_enabled ? 1 : 0
-    source                                        = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v6.2.1"
+    source                                        = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
     name                                          = "${local.project_replica}-pgres-flexible-snet"
     address_prefixes                              = var.geo_replica_cidr_subnet_postgresql
     resource_group_name                           = data.azurerm_resource_group.rg_vnet.name
@@ -112,7 +112,7 @@ variable "main_server_additional_alerts" {
   }
 
   module "postgresql_fdr_replica_db" {
-    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server_replica?ref=<version>"
+    source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgres_flexible_server_replica?ref=v8.8.0"
     count = var.geo_replica_enabled ? 1 : 0
   
     name = "${local.project_replica}-flexible-postgresql"

--- a/postgresql_server/README.md
+++ b/postgresql_server/README.md
@@ -99,7 +99,7 @@ resource "azurerm_resource_group" "data_rg" {
 
 ## Database subnet
 module "postgres_snet" {
-  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                                      = "${local.project}-postgres-snet"
   address_prefixes                          = var.cidr_subnet_postgres
   resource_group_name                       = azurerm_resource_group.rg_vnet.name
@@ -109,7 +109,7 @@ module "postgres_snet" {
 }
 
 module "postgres" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgresql_server?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//postgresql_server?ref=v8.8.0"
 
   name                = "${local.project}-postgres"
   location            = azurerm_resource_group.data_rg.location

--- a/redis_cache/README.md
+++ b/redis_cache/README.md
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "redis" {
 
 ## redisbase subnet
 module "redis_snet" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                 = "${local.project}-redis-snet"
   address_prefixes     = var.cidr_subnet_redis
   resource_group_name  = azurerm_resource_group.rg_vnet.name
@@ -22,7 +22,7 @@ module "redis_snet" {
 
 module "redis" {
   count                 = var.redis_enabled ? 1 : 0
-  source                = "git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache?ref=v3.15.0"
+  source                = "git::https://github.com/pagopa/terraform-azurerm-v3.git//redis_cache?ref=v8.8.0"
   name                  = "${local.project}-redis"
   resource_group_name   = azurerm_resource_group.redis.name
   location              = azurerm_resource_group.redis.location

--- a/storage_account/README.md
+++ b/storage_account/README.md
@@ -20,7 +20,7 @@ Use the example Terraform template, saved in `tests`, to test this module.
 #####
 module "backupstorage" {
   count  = 1
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v6.2.1"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_account?ref=v8.8.0"
 
   name                            = replace("${local.project}-backupstorage", "-", "")
   account_kind                    = "StorageV2"
@@ -71,7 +71,7 @@ resource "azurerm_private_endpoint" "backupstorage_private_endpoint" {
 module "private_endpoint_snet" {
   count = var.enable.core.private_endpoints_subnet ? 1 : 0
 
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v6.2.1"
+  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                 = "private-endpoint-snet"
   resource_group_name  = azurerm_resource_group.rg_vnet.name
   virtual_network_name = module.vnet.name

--- a/storage_account/README.md
+++ b/storage_account/README.md
@@ -20,40 +20,40 @@ Use the example Terraform template, saved in `tests`, to test this module.
 
 ## Known Issues
 
-- Applying the immutability policy on an existing storage account fails due to a 404 NotFound error on the threat protection creation for the new storage. Solution, delete the resource and create the new one with the immutability policy.
-- Changing the `period_since_creation_in_days` will be updated in terraform state but not in the cloud provider resource. Solution, change the value using the Azure portal.
+* Applying the immutability policy on an existing storage account fails due to a 404 NotFound error on the threat protection creation for the new storage. Solution, delete the resource and create the new one with the immutability policy.
+* Changing the `period_since_creation_in_days` will be updated in terraform state but not in the cloud provider resource. Solution, change the value using the Azure portal.
 
 ## Migration from v2
 
 🆕 To use this module you need to use change this variables/arguments:
 
-- `blob_properties_delete_retention_policy_days` -> `blob_delete_retention_days`
-- `allow_blob_public_access` -> `allow_nested_items_to_be_public`
-- `enable_versioning` -> `blob_versioning_enabled`
+* `blob_properties_delete_retention_policy_days` -> `blob_delete_retention_days`
+* `allow_blob_public_access` -> `allow_nested_items_to_be_public`
+* `enable_versioning` -> `blob_versioning_enabled`
 
 ❌ Don't use this variables:
 
-- `enable_https_traffic_only` -> don't use any more, now default is true and mandatory
-- `versioning_name`
+* `enable_https_traffic_only` -> don't use any more, now default is true and mandatory
+* `versioning_name`
 
 ❌ Don't use locks because are managed outside of the module:
 
-- `lock_enabled`
-- `lock_name`
-- `lock_level`  
-- `lock_notes`
+* `lock_enabled`
+* `lock_name`
+* `lock_level`  
+* `lock_notes`
 
 🔥 destroied resources
 
-- `module.<name>.azurerm_template_deployment.versioning[0]` is destroied becuase we use an internal variable and not more an arm.
+* `module.<name>.azurerm_template_deployment.versioning[0]` is destroied becuase we use an internal variable and not more an arm.
 
 ### Migration results
 
 During the apply there will be this result:
 
-- 1 changed (related to storage, that need to update one property `cross_tenant_replication_enabled`)
+* 1 changed (related to storage, that need to update one property `cross_tenant_replication_enabled`)
 
-- 2 destroy (related to storage, that need to destroy the old arm command for versioning `azurerm_template_deployment.versioning`)
+* 2 destroy (related to storage, that need to destroy the old arm command for versioning `azurerm_template_deployment.versioning`)
 
 like this:
 

--- a/storage_management_policy/README.md
+++ b/storage_management_policy/README.md
@@ -7,7 +7,7 @@ This module allow the creation of a management policy for storage account
 ```ts
 module "storage_account_durable_function_management_policy" {
   count  = length(local.internal_containers) == 0 ? 0 : 1
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_management_policy?ref=v3.13.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//storage_management_policy?ref=v8.8.0"
 
   storage_account_id = module.storage_account_durable_function[0].id
 

--- a/subnet/README.md
+++ b/subnet/README.md
@@ -8,7 +8,7 @@ This module allow the creation of subnet
 
 ```ts
 module "private_endpoints_snet" {
-  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+  source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                 = "${local.program}-private-endpoints-snet"
   address_prefixes     = var.cidr_subnet_private_endpoints
   virtual_network_name = data.azurerm_virtual_network.vnet.name
@@ -28,7 +28,7 @@ module "private_endpoints_snet" {
 
 ```ts
 module "funcs_diego_snet" {
-  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                                      = "${local.project}-funcs-snet"
   address_prefixes                          = var.cidr_subnet_funcs_diego_domain
   resource_group_name                       = data.azurerm_resource_group.rg_vnet_core.name

--- a/tls_checker/README.md
+++ b/tls_checker/README.md
@@ -6,7 +6,7 @@ This modules allow the creation of a tls checker using <https://pagopa.github.io
 
 ```ts
 module "tls_checker" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//tls_checker?ref=tls_cheker_improve_docs"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//tls_checker?ref=v8.8.0"
 
   https_endpoint                      = local.ecommerce_hostname
   alert_name                          = local.ecommerce_hostname

--- a/virtual_network/README.md
+++ b/virtual_network/README.md
@@ -7,7 +7,7 @@ This module create a virtual network
 ```ts
 # vnet
 module "vnet" {
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network?ref=v3.15.0"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network?ref=v8.8.0"
   name                = local.vnet_name
   location            = azurerm_resource_group.rg_vnet.location
   resource_group_name = azurerm_resource_group.rg_vnet.name

--- a/virtual_network_peering/README.md
+++ b/virtual_network_peering/README.md
@@ -6,7 +6,7 @@ This module allow the creation of a virtual network peering
 
 ```ts
 module "vnet_peering_core_2_aks" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network_peering?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network_peering?ref=v8.8.0"
 
   for_each = { for n in var.aks_networks : n.domain_name => n }
 

--- a/vm_scale_set/README.md
+++ b/vm_scale_set/README.md
@@ -9,7 +9,7 @@ This module allows the creation of Linux virtual machine scale set (VMSS) with a
 # with default image
 module "vmss" {
 
-  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//vm_scale_set?ref=7.47.0"
+  source              = "git::https://github.com/pagopa/terraform-azurerm-v3.git//vm_scale_set?ref=v8.8.0"
 
   name                = var.name
   resource_group_name = data.azurerm_resource_group.rg_vnet_core.name

--- a/vpn_gateway/README.md
+++ b/vpn_gateway/README.md
@@ -7,7 +7,7 @@ This module allow the creation of vpn gateway
 ```ts
 ## VPN subnet
 module "vpn_snet" {
-  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v3.15.0"
+  source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v8.8.0"
   name                                      = "GatewaySubnet"
   address_prefixes                          = var.cidr_subnet_vpn
   virtual_network_name                      = module.vnet.name
@@ -21,7 +21,7 @@ data "azuread_application" "vpn_app" {
 }
 
 module "vpn" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//vpn_gateway?ref=v3.15.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//vpn_gateway?ref=v8.8.0"
 
   name                = "${local.project}-vpn"
   location            = var.location


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- fix modules that use storage account 
- updated all modules to v8.8.0
- updated readme

### Motivation and context

Fix internal modules, CDN and data-indexer that use storage account v8.8.0, this module removed this variable `enable_resource_advanced_threat_protection` that broke the other modules

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
