### PR TITLE
feat: Azdo agent added vmss_instances parameter

### DIFF
--- a/azure_devops_agent/README.md
+++ b/azure_devops_agent/README.md
@@ -109,6 +109,7 @@ No modules.
 | <a name="input_storage_sku"></a> [storage\_sku](#input\_storage\_sku) | (Optional) The SKU of the storage account with which to persist VM. Use a singular sku that would be applied across all disks, or specify individual disks. Usage: [--storage-sku SKU \| --storage-sku ID=SKU ID=SKU ID=SKU...], where each ID is os or a 0-indexed lun. Allowed values: Standard\_LRS, Premium\_LRS, StandardSSD\_LRS, UltraSSD\_LRS, Premium\_ZRS, StandardSSD\_ZRS. | `string` | `"StandardSSD_LRS"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Required) An existing subnet ID | `string` | `null` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) Azure subscription id | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags | `map(any)` | `{}` | no |
 | <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B2ms"` | no |
 | <a name="input_vmss_instances"></a> [vmss\_instances](#input\_vmss\_instances) | (Optional) The number of Virtual Machines in the Scale Set. Defaults to 0. | `number` | `"0"` | no |
 | <a name="input_zone_balance"></a> [zone\_balance](#input\_zone\_balance) | (Optional) If true forces the even distribution of instances across all the configured zones ('zones' variable) | `bool` | `false` | no |

--- a/azure_devops_agent/README.md
+++ b/azure_devops_agent/README.md
@@ -78,6 +78,7 @@ module "module "azdoa_vmss_li" {" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.30.0, <= 3.97.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | <= 3.2.1 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | <= 4.1.0 |
 
 ## Modules
 
@@ -108,9 +109,8 @@ No modules.
 | <a name="input_storage_sku"></a> [storage\_sku](#input\_storage\_sku) | (Optional) The SKU of the storage account with which to persist VM. Use a singular sku that would be applied across all disks, or specify individual disks. Usage: [--storage-sku SKU \| --storage-sku ID=SKU ID=SKU ID=SKU...], where each ID is os or a 0-indexed lun. Allowed values: Standard\_LRS, Premium\_LRS, StandardSSD\_LRS, UltraSSD\_LRS, Premium\_ZRS, StandardSSD\_ZRS. | `string` | `"StandardSSD_LRS"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Required) An existing subnet ID | `string` | `null` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) Azure subscription id | `string` | n/a | yes |
-| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | (Required) Azure subscription name | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
-| <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B1s"` | no |
+| <a name="input_vm_sku"></a> [vm\_sku](#input\_vm\_sku) | (Optional) Size of VMs in the scale set. Default to Standard\_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info. | `string` | `"Standard_B2ms"` | no |
+| <a name="input_vmss_instances"></a> [vmss\_instances](#input\_vmss\_instances) | (Optional) The number of Virtual Machines in the Scale Set. Defaults to 0. | `number` | `"0"` | no |
 | <a name="input_zone_balance"></a> [zone\_balance](#input\_zone\_balance) | (Optional) If true forces the even distribution of instances across all the configured zones ('zones' variable) | `bool` | `false` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | (Optional) List of AZ on which the scale set will distribute its instances | `list(string)` | `null` | no |
 

--- a/azure_devops_agent/main.tf
+++ b/azure_devops_agent/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   resource_group_name = var.resource_group_name
   location            = var.location
   sku                 = var.vm_sku
-  instances           = 1
+  instances           = var.vmss_instances
   admin_username      = "adminuser"
   admin_password      = var.admin_password
 

--- a/azure_devops_agent/main.tf
+++ b/azure_devops_agent/main.tf
@@ -82,6 +82,5 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     ]
   }
 
-  tags = var.tags
 }
 

--- a/azure_devops_agent/main.tf
+++ b/azure_devops_agent/main.tf
@@ -81,5 +81,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
       tags["__AzureDevOpsElasticPoolTimeStamp"],
     ]
   }
+
+  tags = var.tags
 }
 

--- a/azure_devops_agent/variables.tf
+++ b/azure_devops_agent/variables.tf
@@ -9,11 +9,6 @@ variable "name" {
   description = "(Required) The name of the Linux Virtual Machine Scale Set. Changing this forces a new resource to be created."
 }
 
-variable "subscription_name" {
-  type        = string
-  description = "(Required) Azure subscription name"
-}
-
 variable "subscription_id" {
   type        = string
   description = "(Required) Azure subscription id"
@@ -63,10 +58,16 @@ variable "image_type" {
   }
 }
 
+variable "vmss_instances" {
+  type        = number
+  description = "(Optional) The number of Virtual Machines in the Scale Set. Defaults to 0."
+  default     = "0"
+}
+
 variable "vm_sku" {
   type        = string
   description = "(Optional) Size of VMs in the scale set. Default to Standard_B1s. See https://azure.microsoft.com/pricing/details/virtual-machines/ for size info."
-  default     = "Standard_B1s"
+  default     = "Standard_B2ms"
 }
 
 variable "storage_sku" {
@@ -106,11 +107,6 @@ variable "admin_password" {
   description = "(Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created. will be stored in the raw state as plain-text"
   default     = null
 }
-
-variable "tags" {
-  type = map(any)
-}
-
 
 variable "zones" {
   type        = list(string)

--- a/azure_devops_agent/variables.tf
+++ b/azure_devops_agent/variables.tf
@@ -120,3 +120,9 @@ variable "zone_balance" {
   description = "(Optional) If true forces the even distribution of instances across all the configured zones ('zones' variable)"
 }
 
+variable "tags" {
+  type        = map(any)
+  description = "Tags"
+  default     = {}
+}
+

--- a/azure_devops_agent/versions.tf
+++ b/azure_devops_agent/versions.tf
@@ -6,9 +6,15 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.30.0, <= 3.97.1"
     }
+
     null = {
       source  = "hashicorp/null"
       version = "<= 3.2.1"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "<= 4.1.0"
     }
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- now you can configure the number of vmss instance, default 0 for azure devops
- removed variables not used
- default sku vm is B2ms

### Motivation and context

Azure devops when use a vmss put it to zero by default, but the module had 1 by default. Now is zero by default

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
