### PR TITLE
fix: Add Storage ID as output for CDN module

### DIFF
--- a/cdn/README.md
+++ b/cdn/README.md
@@ -168,6 +168,7 @@ During the apply there will be 1 changed and 1 destroy related to storage see [s
 | <a name="output_id"></a> [id](#output\_id) | Deprecated, use endpoint\_id instead. |
 | <a name="output_name"></a> [name](#output\_name) | n/a |
 | <a name="output_profile_id"></a> [profile\_id](#output\_profile\_id) | n/a |
+| <a name="output_storage_id"></a> [storage\_id](#output\_storage\_id) | n/a |
 | <a name="output_storage_primary_access_key"></a> [storage\_primary\_access\_key](#output\_storage\_primary\_access\_key) | n/a |
 | <a name="output_storage_primary_blob_connection_string"></a> [storage\_primary\_blob\_connection\_string](#output\_storage\_primary\_blob\_connection\_string) | n/a |
 | <a name="output_storage_primary_blob_host"></a> [storage\_primary\_blob\_host](#output\_storage\_primary\_blob\_host) | n/a |

--- a/cdn/outputs.tf
+++ b/cdn/outputs.tf
@@ -23,6 +23,10 @@ output "fqdn" {
   value = var.dns_zone_name == var.hostname ? trimsuffix(azurerm_dns_a_record.apex_hostname[0].fqdn, ".") : trimsuffix(azurerm_dns_cname_record.hostname[0].fqdn, ".")
 }
 
+output "storage_id" {
+  value = module.cdn_storage_account.id
+}
+
 output "storage_primary_connection_string" {
   value     = module.cdn_storage_account.primary_connection_string
   sensitive = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* add `storage_id` output to `cdn` module

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The CDN module creates a storage account. Having the resource id allow other modules to reference the storage account (for example, to setup write permission on items)

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
