### PR TITLE
feat: Added public_network_access_enabled property in function_app and function_app_slot

### DIFF
--- a/function_app/README.md
+++ b/function_app/README.md
@@ -256,6 +256,7 @@ See [Generic resource migration](../.docs/MIGRATION_GUIDE_GENERIC_RESOURCES.md)
 | <a name="input_docker"></a> [docker](#input\_docker) | ##################### Framework choice ##################### | `any` | `{}` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Specifies the domain of the Function App. | `string` | `null` | no |
 | <a name="input_dotnet_version"></a> [dotnet\_version](#input\_dotnet\_version) | n/a | `string` | `null` | no |
+| <a name="input_enable_function_app_public_network_access"></a> [enable\_function\_app\_public\_network\_access](#input\_enable\_function\_app\_public\_network\_access) | (Optional) Should public network access be enabled for the Function App. Defaults to true. | `bool` | `true` | no |
 | <a name="input_enable_healthcheck"></a> [enable\_healthcheck](#input\_enable\_healthcheck) | Enable the healthcheck alert. Default is true | `bool` | `true` | no |
 | <a name="input_export_keys"></a> [export\_keys](#input\_export\_keys) | n/a | `bool` | `false` | no |
 | <a name="input_health_check_maxpingfailures"></a> [health\_check\_maxpingfailures](#input\_health\_check\_maxpingfailures) | Max ping failures allowed | `number` | `10` | no |

--- a/function_app/main.tf
+++ b/function_app/main.tf
@@ -227,11 +227,12 @@ resource "azurerm_linux_function_app" "this" {
   functions_extension_version = var.runtime_version
   service_plan_id             = var.app_service_plan_id != null ? var.app_service_plan_id : azurerm_service_plan.this[0].id
   #  The backend storage account name which will be used by this Function App (such as the dashboard, logs)
-  storage_account_name       = module.storage_account.name
-  storage_account_access_key = module.storage_account.primary_access_key
-  https_only                 = var.https_only
-  client_certificate_enabled = var.client_certificate_enabled
-  client_certificate_mode    = var.client_certificate_mode
+  storage_account_name          = module.storage_account.name
+  storage_account_access_key    = module.storage_account.primary_access_key
+  https_only                    = var.https_only
+  client_certificate_enabled    = var.client_certificate_enabled
+  client_certificate_mode       = var.client_certificate_mode
+  public_network_access_enabled = var.enable_function_app_public_network_access
 
   site_config {
     minimum_tls_version               = "1.2"

--- a/function_app/variables.tf
+++ b/function_app/variables.tf
@@ -264,6 +264,12 @@ variable "app_service_logs" {
   default     = null
 }
 
+variable "enable_function_app_public_network_access" {
+  type        = bool
+  description = "(Optional) Should public network access be enabled for the Function App. Defaults to true."
+  default     = true
+}
+
 # -------------------
 # Alerts variables
 # -------------------

--- a/function_app_slot/main.tf
+++ b/function_app_slot/main.tf
@@ -6,13 +6,14 @@ locals {
 }
 
 resource "azurerm_linux_function_app_slot" "this" {
-  name                        = var.name
-  function_app_id             = var.function_app_id
-  storage_account_name        = var.storage_account_name
-  storage_account_access_key  = var.storage_account_access_key
-  https_only                  = var.https_only
-  client_certificate_enabled  = var.client_certificate_enabled
-  functions_extension_version = var.runtime_version
+  name                          = var.name
+  function_app_id               = var.function_app_id
+  storage_account_name          = var.storage_account_name
+  storage_account_access_key    = var.storage_account_access_key
+  https_only                    = var.https_only
+  client_certificate_enabled    = var.client_certificate_enabled
+  functions_extension_version   = var.runtime_version
+  public_network_access_enabled = var.enable_function_app_public_network_access
 
   site_config {
     minimum_tls_version       = "1.2"

--- a/function_app_slot/variables.tf
+++ b/function_app_slot/variables.tf
@@ -156,6 +156,12 @@ variable "client_certificate_enabled" {
   default     = false
 }
 
+variable "enable_function_app_public_network_access" {
+  type        = bool
+  description = "(Optional) Should public network access be enabled for the Function App. Defaults to true."
+  default     = true
+}
+
 ######################
 # Framework choice
 ######################


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Added `public_network_access_enabled` property inside the `function_app` and `function_app_slot` modules for the resources `azurerm_linux_function_app` and `azurerm_linux_function_app_slot`.
To avoid breaking changes the default of the variable is set to `true`, as the resource default.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
As specified in the PR for task [IOPLT-547](https://github.com/pagopa/trial-system/pull/104) this property is needed to block public connectivity.


### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```


[IOPLT-547]: https://pagopa.atlassian.net/browse/IOPLT-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ