### PR TITLE
fix: Apim api resource - add api_type attribute

### DIFF
--- a/api_management_api/README.md
+++ b/api_management_api/README.md
@@ -84,6 +84,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_management_name"></a> [api\_management\_name](#input\_api\_management\_name) | n/a | `string` | n/a | yes |
 | <a name="input_api_operation_policies"></a> [api\_operation\_policies](#input\_api\_operation\_policies) | List of api policy for given operation. | <pre>list(object({<br>    operation_id = string<br>    xml_content  = string<br>    }<br>  ))</pre> | `[]` | no |
+| <a name="input_api_type"></a> [api\_type](#input\_api\_type) | (Optional) Type of API. Possible values are graphql, http, soap, and websocket. Defaults to http. | `string` | `"http"` | no |
 | <a name="input_api_version"></a> [api\_version](#input\_api\_version) | The Version number of this API, if this API is versioned. | `string` | `null` | no |
 | <a name="input_content_format"></a> [content\_format](#input\_content\_format) | The format of the content from which the API Definition should be imported. | `string` | `"swagger-json"` | no |
 | <a name="input_content_value"></a> [content\_value](#input\_content\_value) | The Content from which the API Definition should be imported. | `string` | n/a | yes |

--- a/api_management_api/main.tf
+++ b/api_management_api/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_api_management_api" "this" {
   revision_description = var.revision_description
   display_name         = var.display_name
   description          = var.description
+  api_type             = var.api_type
 
   dynamic "oauth2_authorization" {
     for_each = var.oauth2_authorization.authorization_server_name != null ? ["dummy"] : []

--- a/api_management_api/variables.tf
+++ b/api_management_api/variables.tf
@@ -32,6 +32,12 @@ variable "revision_description" {
   default = null
 }
 
+variable "api_type" {
+  type        = string
+  default     = "http"
+  description = "(Optional) Type of API. Possible values are graphql, http, soap, and websocket. Defaults to http."
+}
+
 variable "oauth2_authorization" {
   type = object({
     authorization_server_name = string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

In the resource `azurerm_api_management_api`, the attribute `api_type` is added with a default value of 'http'.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
