### PR TITLE
fix: Add variable to AppService modules to drive public connectivity

### DIFF
--- a/app_service/README.md
+++ b/app_service/README.md
@@ -102,6 +102,7 @@ No modules.
 | <a name="input_plan_name"></a> [plan\_name](#input\_plan\_name) | (Optional) Specifies the name of the App Service Plan component. Changing this forces a new resource to be created. | `string` | `null` | no |
 | <a name="input_plan_per_site_scaling"></a> [plan\_per\_site\_scaling](#input\_plan\_per\_site\_scaling) | (Optional) Can Apps assigned to this App Service Plan be scaled independently? If set to false apps assigned to this plan will scale to all instances of the plan. Defaults to false. | `bool` | `false` | no |
 | <a name="input_plan_type"></a> [plan\_type](#input\_plan\_type) | (Required) Specifies if app service plan is external or internal | `string` | `"internal"` | no |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | (Optional) Should public network access be enabled for the App Service. Defaults to true. | `bool` | `true` | no |
 | <a name="input_python_version"></a> [python\_version](#input\_python\_version) | n/a | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the resource group in which to create the App Service and App Service Plan. | `string` | n/a | yes |
 | <a name="input_ruby_version"></a> [ruby\_version](#input\_ruby\_version) | n/a | `string` | `null` | no |

--- a/app_service/main.tf
+++ b/app_service/main.tf
@@ -28,8 +28,9 @@ resource "azurerm_linux_web_app" "this" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  service_plan_id = var.plan_type == "internal" ? azurerm_service_plan.this[0].id : var.plan_id
-  https_only      = var.https_only
+  service_plan_id               = var.plan_type == "internal" ? azurerm_service_plan.this[0].id : var.plan_id
+  https_only                    = var.https_only
+  public_network_access_enabled = var.public_network_access_enabled
   #tfsec:ignore:azure-appservice-require-client-cert
   client_certificate_enabled = var.client_cert_enabled
   client_affinity_enabled    = var.client_affinity_enabled

--- a/app_service/variables.tf
+++ b/app_service/variables.tf
@@ -150,6 +150,12 @@ variable "vnet_integration" {
   default     = false
 }
 
+variable "public_network_access_enabled" {
+  type        = bool
+  description = "(Optional) Should public network access be enabled for the App Service. Defaults to true."
+  default     = true
+}
+
 variable "subnet_id" {
   type        = string
   description = "(Optional) Subnet id wether you want to integrate the app service to a subnet."

--- a/app_service_slot/README.md
+++ b/app_service_slot/README.md
@@ -96,6 +96,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | (Required) Specifies the name of the App Service. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_node_version"></a> [node\_version](#input\_node\_version) | n/a | `string` | `null` | no |
 | <a name="input_php_version"></a> [php\_version](#input\_php\_version) | n/a | `string` | `null` | no |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | (Optional) Should public network access be enabled for the App Service. Defaults to true. | `bool` | `true` | no |
 | <a name="input_python_version"></a> [python\_version](#input\_python\_version) | n/a | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the resource group in which to create the App Service and App Service Plan. | `string` | n/a | yes |
 | <a name="input_ruby_version"></a> [ruby\_version](#input\_ruby\_version) | n/a | `string` | `null` | no |

--- a/app_service_slot/main.tf
+++ b/app_service_slot/main.tf
@@ -1,10 +1,11 @@
 resource "azurerm_linux_web_app_slot" "this" {
   name = var.name
 
-  app_service_id             = var.app_service_id
-  https_only                 = var.https_only
-  client_affinity_enabled    = var.client_affinity_enabled
-  client_certificate_enabled = var.client_certificate_enabled
+  app_service_id                = var.app_service_id
+  https_only                    = var.https_only
+  public_network_access_enabled = var.public_network_access_enabled
+  client_affinity_enabled       = var.client_affinity_enabled
+  client_certificate_enabled    = var.client_certificate_enabled
 
   # https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   app_settings = merge(

--- a/app_service_slot/variables.tf
+++ b/app_service_slot/variables.tf
@@ -38,6 +38,12 @@ variable "client_affinity_enabled" {
   default     = false
 }
 
+variable "public_network_access_enabled" {
+  type        = bool
+  description = "(Optional) Should public network access be enabled for the App Service. Defaults to true."
+  default     = true
+}
+
 ## App service slot
 variable "name" {
   type        = string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add `public_network_access_enabled` to `app_service` and `app_service_slot` modules

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

If a private endpoint is created, the public network connectivity flag must set to false

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
