### PR TITLE
fix: Application insights web test preview fixed web_test_id formatting

### DIFF
--- a/application_insights_web_test_preview/main.tf
+++ b/application_insights_web_test_preview/main.tf
@@ -30,13 +30,13 @@ resource "azurerm_monitor_metric_alert" "this" {
   severity            = var.severity
   scopes = [
     var.application_insight_id,
-    "/subscriptions/${var.subscription_id}/resourcegroups/${var.resource_group}/providers/microsoft.insights/webTests/${var.name}-${var.application_insight_name}",
+    "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}/providers/Microsoft.Insights/webTests/${var.name}-${var.application_insight_name}",
   ]
   description   = var.alert_description
   auto_mitigate = var.auto_mitigate
 
   application_insights_web_test_location_availability_criteria {
-    web_test_id           = "/subscriptions/${var.subscription_id}/resourcegroups/${var.resource_group}/providers/microsoft.insights/webTests/${var.name}-${var.application_insight_name}"
+    web_test_id           = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}/providers/Microsoft.Insights/webTests/${var.name}-${var.application_insight_name}"
     component_id          = var.application_insight_id
     failed_location_count = var.failed_location_count
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->


### List of changes

<!--- Describe your changes in detail -->
Fixed cases in web_test_id in application insights web test preview module
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Using this module with newer versions of terraform causes the following fail due to case sensitivity:
<img width="1776" alt="Screenshot 2024-07-22 alle 14 41 37" src="https://github.com/user-attachments/assets/9c5ef1fe-a8c8-4f09-b49b-b49ea4c5cfc6">

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
