### PR TITLE
fix: Prevent recreation of dns-forwarder containers during import

### DIFF
--- a/dns_forwarder/README.md
+++ b/dns_forwarder/README.md
@@ -68,6 +68,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_container_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_group) | resource |
+| [null_resource.secret_trigger](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [local_file.corefile](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs

--- a/dns_forwarder/main.tf
+++ b/dns_forwarder/main.tf
@@ -32,8 +32,19 @@ resource "azurerm_container_group" "this" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes       = [container[0].volume[0].secret]
+    replace_triggered_by = [null_resource.secret_trigger.id]
+  }
 }
 
 data "local_file" "corefile" {
   filename = format("%s/Corefile", path.module)
+}
+
+resource "null_resource" "secret_trigger" {
+  triggers = {
+    trigger = base64encode(data.local_file.corefile.content)
+  }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Added lifecycle and trigger on dns-resolver container group

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This issue appears while moving io-infra core resources related to the VPN to the new modular structure.
During the import of the existing resources, although no changes are done, the container group that runs the opendns server requires recreation.

![image](https://github.com/user-attachments/assets/8b799cff-4e67-467b-974e-4df3d009f27f)

Since the issue comes directly from the provider, [a workaround](https://github.com/hashicorp/terraform-provider-azurerm/issues/16999) has been identified and implemented in this PR.

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The change included in this PR has been tested and gives the expected result:

![image](https://github.com/user-attachments/assets/22a3b000-1530-4129-b9a5-7f3dc1f0edcd)

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
