### PR TITLE
feat: Azdo agent image updated with packer

### DIFF
--- a/azure_devops_agent_custom_image/README.md
+++ b/azure_devops_agent_custom_image/README.md
@@ -56,7 +56,7 @@ module "azdoa_custom_image" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.47 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.30 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.100 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 

--- a/azure_devops_agent_custom_image/packer/script-config.sh
+++ b/azure_devops_agent_custom_image/packer/script-config.sh
@@ -29,9 +29,12 @@ az acr helm install-cli -y --client-version 3.14.2
 check_command "helm"
 
 # install kubectl
-az aks install-cli --client-version 1.27.12 --kubelogin-version 0.1.3
+# https://kubernetes.io/releases/
+# https://github.com/Azure/kubelogin/releases
+az aks install-cli --client-version 1.29.7 --kubelogin-version 0.1.4
 
 check_command "kubectl"
+check_command "kubelogin"
 
 # setup DOCKER installation from https://docs.docker.com/engine/install/ubuntu/
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
@@ -60,7 +63,7 @@ wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY
 check_command "yq"
 
 # install SOPS from https://github.com/mozilla/sops
-SOPS_VERSION="3.8.1"
+SOPS_VERSION="3.9.0"
 wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops_${SOPS_VERSION}_amd64.deb"
 apt install -y "$PWD/sops_${SOPS_VERSION}_amd64.deb"
 
@@ -75,25 +78,13 @@ sudo mv velero-${VELERO_VERSION}-linux-amd64/velero /usr/bin/velero
 check_command "velero"
 
 # install packer
-curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - && \
-sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" $$ \
-sudo apt-get update && sudo apt-get install -y packer
+curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null && \
+sudo apt-get update && \
+sudo apt-get install -y packer
 
 check_command "packer"
 
-# install azure az repos
-sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
-sudo mkdir -p /etc/apt/keyrings
-curl -sLS https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
-sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
-AZ_DIST=$(lsb_release -cs)
-echo "Types: deb
-URIs: https://packages.microsoft.com/repos/azure-cli/
-Suites: ${AZ_DIST}
-Components: main
-Architectures: $(dpkg --print-architecture)
-Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
-sudo apt-get update
 # prepare machine for k6 large load test
 
 sysctl -w net.ipv4.ip_local_port_range="1024 65535"

--- a/azure_devops_agent_custom_image/versions.tf
+++ b/azure_devops_agent_custom_image/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.30"
+      version = "~> 3.100"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- updated azdo agent image to allow to have kubectl 1.29.x version and kubelogin 0.1.4 version, and update all software 

### Motivation and context

Use the kubectl 1.29 version to avoid future problems and have the same version of kubectl like ours clusters

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
