### PR TITLE
feat: Add variable to control APIM subscription header/query string name

### DIFF
--- a/api_management_api/README.md
+++ b/api_management_api/README.md
@@ -99,6 +99,7 @@ No modules.
 | <a name="input_revision"></a> [revision](#input\_revision) | n/a | `string` | `"1"` | no |
 | <a name="input_revision_description"></a> [revision\_description](#input\_revision\_description) | n/a | `string` | `null` | no |
 | <a name="input_service_url"></a> [service\_url](#input\_service\_url) | n/a | `string` | n/a | yes |
+| <a name="input_subscription_key_names"></a> [subscription\_key\_names](#input\_subscription\_key\_names) | Override the default name of the header and query string containing the subscription key header | <pre>object({<br>    header = string<br>    query  = string<br>  })</pre> | `null` | no |
 | <a name="input_subscription_required"></a> [subscription\_required](#input\_subscription\_required) | Should this API require a subscription key? | `bool` | `false` | no |
 | <a name="input_version_set_id"></a> [version\_set\_id](#input\_version\_set\_id) | The ID of the Version Set which this API is associated with. | `string` | `null` | no |
 | <a name="input_xml_content"></a> [xml\_content](#input\_xml\_content) | The XML Content for this Policy as a string | `string` | `null` | no |

--- a/api_management_api/main.tf
+++ b/api_management_api/main.tf
@@ -27,6 +27,13 @@ resource "azurerm_api_management_api" "this" {
     content_value  = var.content_value
   }
 
+  dynamic "subscription_key_parameter_names" {
+    for_each = var.subscription_key_names == null ? [] : ["dummy"]
+    content {
+      header = var.subscription_key_names.header
+      query  = var.subscription_key_names.query
+    }
+  }
 }
 
 resource "azurerm_api_management_api_policy" "this" {

--- a/api_management_api/variables.tf
+++ b/api_management_api/variables.tf
@@ -105,3 +105,12 @@ variable "version_set_id" {
   description = "The ID of the Version Set which this API is associated with."
   default     = null
 }
+
+variable "subscription_key_names" {
+  type = object({
+    header = string
+    query  = string
+  })
+  description = "Override the default name of the header and query string containing the subscription key header"
+  default     = null
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Add variable to control APIM subscription header/query string name

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Client could invoke an API exposed via APIM using another header/query string name rather than the default one (`Ocp-Apim-Subscription-Key`/`subscription-key`) to include the subscription key. Sometimes, updating the client behaviour is more difficult and risky than changing the behaviour of a new API group

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
