### PR TITLE
feat: Allowing to set labels for github runners

### DIFF
--- a/container_app_job_gh_runner/README.md
+++ b/container_app_job_gh_runner/README.md
@@ -105,14 +105,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_container"></a> [container](#input\_container) | Job Container configuration | <pre>object({<br/>    cpu    = number<br/>    memory = string<br/>    image  = string<br/>  })</pre> | <pre>{<br/>  "cpu": 0.5,<br/>  "image": "ghcr.io/pagopa/github-self-hosted-runner-azure:latest",<br/>  "memory": "1Gi"<br/>}</pre> | no |
+| <a name="input_container"></a> [container](#input\_container) | Job Container configuration | <pre>object({<br>    cpu    = number<br>    memory = string<br>    image  = string<br>  })</pre> | <pre>{<br>  "cpu": 0.5,<br>  "image": "ghcr.io/pagopa/github-self-hosted-runner-azure:latest",<br>  "memory": "1Gi"<br>}</pre> | no |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Short environment prefix | `string` | n/a | yes |
-| <a name="input_environment"></a> [environment](#input\_environment) | Container App Environment configuration (Log Analytics Workspace) | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>  })</pre> | n/a | yes |
-| <a name="input_job"></a> [job](#input\_job) | Container App job configuration | <pre>object({<br/>    name                 = string<br/>    repo_owner           = optional(string, "pagopa")<br/>    repo                 = string<br/>    polling_interval     = optional(number, 30)<br/>    scale_max_executions = optional(number, 5)<br/>  })</pre> | n/a | yes |
-| <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | Data of the KeyVault which stores PAT as secret | <pre>object({<br/>    resource_group_name = string<br/>    name                = string<br/>    secret_name         = string<br/>  })</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Container App Environment configuration (Log Analytics Workspace) | <pre>object({<br>    name                = string<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
+| <a name="input_job"></a> [job](#input\_job) | Container App job configuration | <pre>object({<br>    name                 = string<br>    repo_owner           = optional(string, "pagopa")<br>    repo                 = string<br>    polling_interval     = optional(number, 30)<br>    scale_max_executions = optional(number, 5)<br>  })</pre> | n/a | yes |
+| <a name="input_key_vault"></a> [key\_vault](#input\_key\_vault) | Data of the KeyVault which stores PAT as secret | <pre>object({<br>    resource_group_name = string<br>    name                = string<br>    secret_name         = string<br>  })</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Resource group and resources location | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Project prefix | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags for new resources | `map(any)` | <pre>{<br/>  "CreatedBy": "Terraform"<br/>}</pre> | no |
+| <a name="input_runner_labels"></a> [runner\_labels](#input\_runner\_labels) | Labels that allow a GH action to call a specific runner | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags for new resources | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
 
 ## Outputs
 

--- a/container_app_job_gh_runner/locals.tf
+++ b/container_app_job_gh_runner/locals.tf
@@ -32,6 +32,10 @@ locals {
       {
         name  = "REGISTRATION_TOKEN_API_URL"
         value = "https://api.github.com/repos/${var.job.repo_owner}/${var.job.repo}/actions/runners/registration-token"
+      },
+      {
+        name = "LABELS"
+        value = join(",", var.runner_labels)
       }
     ]
     image = var.container.image

--- a/container_app_job_gh_runner/locals.tf
+++ b/container_app_job_gh_runner/locals.tf
@@ -34,7 +34,7 @@ locals {
         value = "https://api.github.com/repos/${var.job.repo_owner}/${var.job.repo}/actions/runners/registration-token"
       },
       {
-        name = "LABELS"
+        name  = "LABELS"
         value = join(",", var.runner_labels)
       }
     ]

--- a/container_app_job_gh_runner/variables.tf
+++ b/container_app_job_gh_runner/variables.tf
@@ -81,3 +81,9 @@ variable "key_vault" {
 
   description = "Data of the KeyVault which stores PAT as secret"
 }
+
+variable "runner_labels" {
+  type        = list(string)
+  description = "Labels that allow a GH action to call a specific runner"
+  default     = []
+}

--- a/container_app_job_gh_runner_v2/README.md
+++ b/container_app_job_gh_runner_v2/README.md
@@ -96,12 +96,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_container"></a> [container](#input\_container) | Job Container configuration | <pre>object({<br/>    cpu    = number<br/>    memory = string<br/>    image  = string<br/>  })</pre> | <pre>{<br/>  "cpu": 0.5,<br/>  "image": "ghcr.io/pagopa/github-self-hosted-runner-azure:latest",<br/>  "memory": "1Gi"<br/>}</pre> | no |
+| <a name="input_container"></a> [container](#input\_container) | Job Container configuration | <pre>object({<br>    cpu    = number<br>    memory = string<br>    image  = string<br>  })</pre> | <pre>{<br>  "cpu": 0.5,<br>  "image": "ghcr.io/pagopa/github-self-hosted-runner-azure:latest",<br>  "memory": "1Gi"<br>}</pre> | no |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Short environment prefix | `string` | n/a | yes |
 | <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | (Required) Container App Environment configuration (Log Analytics Workspace) | `string` | n/a | yes |
 | <a name="input_environment_rg"></a> [environment\_rg](#input\_environment\_rg) | (Required) Container App Environment configuration (Log Analytics Workspace) | `string` | n/a | yes |
-| <a name="input_job"></a> [job](#input\_job) | Container App job configuration | <pre>object({<br/>    name                 = string<br/>    scale_max_executions = optional(number, 5)<br/>    scale_min_executions = optional(number, 0)<br/>  })</pre> | n/a | yes |
-| <a name="input_job_meta"></a> [job\_meta](#input\_job\_meta) | Scaling rules metadata. | <pre>object({<br/>    repo                         = string<br/>    repo_owner                   = optional(string, "pagopa")<br/>    runner_scope                 = optional(string, "repo")<br/>    target_workflow_queue_length = optional(string, "1")<br/>    github_runner                = optional(string, "https://api.github.com") #<br/>  })</pre> | n/a | yes |
+| <a name="input_job"></a> [job](#input\_job) | Container App job configuration | <pre>object({<br>    name                 = string<br>    scale_max_executions = optional(number, 5)<br>    scale_min_executions = optional(number, 0)<br>  })</pre> | n/a | yes |
+| <a name="input_job_meta"></a> [job\_meta](#input\_job\_meta) | Scaling rules metadata. | <pre>object({<br>    repo                         = string<br>    repo_owner                   = optional(string, "pagopa")<br>    runner_scope                 = optional(string, "repo")<br>    target_workflow_queue_length = optional(string, "1")<br>    github_runner                = optional(string, "https://api.github.com") #<br>  })</pre> | n/a | yes |
 | <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | Name of the KeyVault which stores PAT as secret | `string` | n/a | yes |
 | <a name="input_key_vault_rg"></a> [key\_vault\_rg](#input\_key\_vault\_rg) | Resource group of the KeyVault which stores PAT as secret | `string` | n/a | yes |
 | <a name="input_key_vault_secret_name"></a> [key\_vault\_secret\_name](#input\_key\_vault\_secret\_name) | Data of the KeyVault which stores PAT as secret | `string` | n/a | yes |
@@ -113,7 +113,8 @@ No modules.
 | <a name="input_replica_retry_limit"></a> [replica\_retry\_limit](#input\_replica\_retry\_limit) | (Optional) The maximum number of times a replica is allowed to retry. | `number` | `1` | no |
 | <a name="input_replica_timeout_in_seconds"></a> [replica\_timeout\_in\_seconds](#input\_replica\_timeout\_in\_seconds) | (Required) The maximum number of seconds a replica is allowed to run. | `number` | `1800` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags for new resources | `map(any)` | <pre>{<br/>  "CreatedBy": "Terraform"<br/>}</pre> | no |
+| <a name="input_runner_labels"></a> [runner\_labels](#input\_runner\_labels) | Labels that allow a GH action to call a specific runner | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags for new resources | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
 
 ## Outputs
 

--- a/container_app_job_gh_runner_v2/locals.tf
+++ b/container_app_job_gh_runner_v2/locals.tf
@@ -34,7 +34,7 @@ locals {
         value = "https://api.github.com/repos/${var.job_meta.repo_owner}/${var.job_meta.repo}/actions/runners/registration-token"
       },
       {
-        name = "LABELS"
+        name  = "LABELS"
         value = join(",", var.runner_labels)
       }
     ]

--- a/container_app_job_gh_runner_v2/locals.tf
+++ b/container_app_job_gh_runner_v2/locals.tf
@@ -32,6 +32,10 @@ locals {
       {
         name  = "REGISTRATION_TOKEN_API_URL"
         value = "https://api.github.com/repos/${var.job_meta.repo_owner}/${var.job_meta.repo}/actions/runners/registration-token"
+      },
+      {
+        name = "LABELS"
+        value = join(",", var.runner_labels)
       }
     ]
     image = var.container.image

--- a/container_app_job_gh_runner_v2/variables.tf
+++ b/container_app_job_gh_runner_v2/variables.tf
@@ -132,3 +132,9 @@ variable "key_vault_secret_name" {
   type        = string
   description = "Data of the KeyVault which stores PAT as secret"
 }
+
+variable "runner_labels" {
+  type        = list(string)
+  description = "Labels that allow a GH action to call a specific runner"
+  default     = []
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Added the environment variable **LABELS** that allows to set labels for github runners

### Motivation and context
The addition of the **LABELS** environment variable in the Terraform configuration for GitHub self-hosted runners is necessary to improve control over where the runners are executed. Currently, in the selfcare-infra setup, runners are started across all three Azure environments. This can lead to unnecessary executions in environments where the runners are not required, potentially causing issues and increasing costs.

By introducing the LABELS variable, we can now target specific environments by applying labels to the runners. This allows GitHub Actions workflows to run only in the designated environments, ensuring better resource management, avoiding unintended deployments, and reducing operational costs.

How to invoke a specific runner in actions:
`runs-on: [self-hosted, <label>]`

For example:
`runs-on: [self-hosted, ${{ inputs.environment }}]`

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
