### PR TITLE
feat: Keda self-hosted runner scaler considers runner's labels

### DIFF
--- a/container_app_job_gh_runner/locals.tf
+++ b/container_app_job_gh_runner/locals.tf
@@ -4,13 +4,13 @@ locals {
   rule = {
     name = "${local.project}-${var.job.name}-github-runner-rule"
     type = "github-runner"
-    metadata = {
+    metadata = merge({
       owner                     = var.job.repo_owner
       runnerScope               = "repo"
       repos                     = "${var.job.repo}"
       targetWorkflowQueueLength = "1"
       github-runner             = "https://api.github.com"
-    }
+    }, length(var.runner_labels) > 0 ? { labels = join(",", var.runner_labels) } : {})
     auth = [
       {
         secretRef        = "personal-access-token"

--- a/container_app_job_gh_runner_v2/locals.tf
+++ b/container_app_job_gh_runner_v2/locals.tf
@@ -4,13 +4,13 @@ locals {
   rule = {
     name = "${local.project}-${var.job.name}-github-runner-rule"
     type = "github-runner"
-    metadata = {
+    metadata = merge({
       owner                     = var.job_meta.repo_owner
       runnerScope               = var.job_meta.runner_scope
       repos                     = "${var.job_meta.repo}"
       targetWorkflowQueueLength = var.job_meta.target_workflow_queue_length
       github-runner             = var.job_meta.github_runner
-    }
+    }, length(var.runner_labels) > 0 ? { labels = join(",", var.runner_labels) } : {})
     auth = [
       {
         secretRef        = "personal-access-token"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add labels metadata to KEDA autoscaler rule
<!--- Describe your changes in detail -->

### Motivation and context
KEDA would not consider labels for runners for which were set. This caused the autoscaler to not spin up containers with the requested label.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
