### PR TITLE
feat: [PAYMCLOUD-192] Add conditional logic for OpenCost management

### DIFF
--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -44,9 +44,9 @@ resource "azurerm_role_assignment" "opencost_identity_role" {
 output "managed_identity_details" {
   description = "Dettagli dell'identità gestita User-Assigned per OpenCost"
   value = jsonencode({
-    identity_id  = azurerm_user_assigned_identity.opencost_identity.0.id
-    principal_id = azurerm_user_assigned_identity.opencost_identity.0.principal_id
-    client_id    = azurerm_user_assigned_identity.opencost_identity.0.client_id
+    identity_id  = var.enable_opencost ? azurerm_user_assigned_identity.opencost_identity.0.id : "N/A"
+    principal_id = var.enable_opencost ? azurerm_user_assigned_identity.opencost_identity.0.principal_id : "N/A"
+    client_id    = var.enable_opencost ? azurerm_user_assigned_identity.opencost_identity.0.client_id : "N/A"
     subscription = data.azurerm_subscription.current.id
     tenant       = data.azurerm_client_config.current.tenant_id
   })

--- a/kubernetes_opencosts/99_variables.tf
+++ b/kubernetes_opencosts/99_variables.tf
@@ -19,6 +19,12 @@ variable "env" {
   }
 }
 
+variable "enable_opencost" {
+  type        = bool
+  default     = false
+  description = "Enable OpenCosts deployment in the cluster"
+}
+
 # AKS Variables
 ###################
 

--- a/kubernetes_opencosts/99_variables.tf
+++ b/kubernetes_opencosts/99_variables.tf
@@ -13,9 +13,9 @@ variable "env" {
   type = string
   validation {
     condition = (
-      length(var.env) <= 3
+      length(var.env) <= 4
     )
-    error_message = "Max length is 3 chars."
+    error_message = "Max length is 4 chars."
   }
 }
 


### PR DESCRIPTION
Description: 
### List of changes
- Updated the "managed_identity_details" output to provide values based on the `enable_opencost` variable.
- Introduced a `enable_opencost` variable for conditional deployment of OpenCost resources.

### Motivation and context
These changes allow for more flexibility in managing OpenCost resources, enabling conditional creation based on the `enable_opencost` variable.

### Type of changes
- [x] Update existing module

### Does this introduce a breaking change?
- [ ] No

### Other information
No additional information provided.

### Run checks
Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```