### PR TITLE
feat: [PAYMCLOUD-198] Emit KSM V1 metrics on opencost module

### DIFF
--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -132,7 +132,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
 
   set {
     name  = "opencost.metrics.kubeStateMetrics.emitKsmV1Metrics"
-    value = "false"
+    value = "true"
   }
 
   set {

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -121,7 +121,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
   }
 
   set {
-    name  = "metrics.serviceMonitor.enabled"
+    name  = "opencost.metrics.serviceMonitor.enabled"
     value = "true"
   }
 

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -79,7 +79,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
   namespace  = data.kubernetes_namespace.monitoring.metadata[0].name
   chart      = "opencost"
   repository = "https://opencost.github.io/opencost-helm-chart/"
-  version    = "1.40.0" # Adjust the version as needed
+  version    = "1.43.0" # Adjust the version as needed
 
   # Set additional values for the Helm chart if required
   set {

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -78,8 +78,8 @@ resource "helm_release" "prometheus_opencost_exporter" {
   name       = "prometheus-opencost-exporter"
   namespace  = data.kubernetes_namespace.monitoring.metadata[0].name
   chart      = "prometheus-opencost-exporter"
-  repository = "https://prometheus-community.github.io/helm-charts"
-  version    = "0.1.1" # Adjust the version as needed
+  repository = "https://opencost.github.io/opencost-helm-chart/"
+  version    = "1.43.0" # Adjust the version as needed
 
   # Set additional values for the Helm chart if required
   set {

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -136,7 +136,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
   }
 
   set {
-    name  = "opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly	"
+    name  = "opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly"
     value = "false"
   }
 

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -137,6 +137,11 @@ resource "helm_release" "prometheus_opencost_exporter" {
 
   set {
     name  = "opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly	"
-    value = "true"
+    value = "false"
+  }
+
+  set {
+    name  = "opencost.ui.enabled"
+    value = "false"
   }
 }

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -79,7 +79,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
   namespace  = data.kubernetes_namespace.monitoring.metadata[0].name
   chart      = "opencost"
   repository = "https://opencost.github.io/opencost-helm-chart/"
-  version    = "1.43.0" # Adjust the version as needed
+  version    = "1.40.0" # Adjust the version as needed
 
   # Set additional values for the Helm chart if required
   set {

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -83,6 +83,11 @@ resource "helm_release" "prometheus_opencost_exporter" {
 
   # Set additional values for the Helm chart if required
   set {
+    name  = "opencost.defaultClusterId"
+    value = data.azurerm_kubernetes_cluster.aks.name
+  }
+
+  set {
     name  = "extraVolumes[0].name"
     value = "azure-managed-identity-secret"
   }

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -124,4 +124,14 @@ resource "helm_release" "prometheus_opencost_exporter" {
     name  = "metrics.serviceMonitor.enabled"
     value = "true"
   }
+
+  set {
+    name  = "opencost.metrics.kubeStateMetrics.emitKsmV1Metrics"
+    value = "false"
+  }
+
+  set {
+    name  = "opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly	"
+    value = "true"
+  }
 }

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -71,7 +71,7 @@ resource "kubernetes_secret" "azure_managed_identity_refs" {
   type = "Opaque"
 }
 
-# # Helm deployment for "prometheus-opencost-exporter"
+# Helm deployment for "prometheus-opencost-exporter"
 resource "helm_release" "prometheus_opencost_exporter" {
   count = var.enable_opencost ? 1 : 0
 
@@ -79,7 +79,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
   namespace  = data.kubernetes_namespace.monitoring.metadata[0].name
   chart      = "opencost"
   repository = "https://opencost.github.io/opencost-helm-chart/"
-  version    = "1.43.0" # Adjust the version as needed
+  version    = var.opencost_helm_chart_version
 
   # Set additional values for the Helm chart if required
   set {

--- a/kubernetes_opencosts/01_main.tf
+++ b/kubernetes_opencosts/01_main.tf
@@ -77,7 +77,7 @@ resource "helm_release" "prometheus_opencost_exporter" {
 
   name       = "prometheus-opencost-exporter"
   namespace  = data.kubernetes_namespace.monitoring.metadata[0].name
-  chart      = "prometheus-opencost-exporter"
+  chart      = "opencost"
   repository = "https://opencost.github.io/opencost-helm-chart/"
   version    = "1.43.0" # Adjust the version as needed
 

--- a/kubernetes_opencosts/99_variables.tf
+++ b/kubernetes_opencosts/99_variables.tf
@@ -63,3 +63,12 @@ variable "prometheus_config" {
     external_url  = ""
   }
 }
+
+# Opencost Variables
+#####################
+
+variable "opencost_helm_chart_version" {
+  type        = string
+  default     = "1.43.0"
+  description = "Helm version of Opencost chart"
+}

--- a/kubernetes_opencosts/99_variables.tf
+++ b/kubernetes_opencosts/99_variables.tf
@@ -1,6 +1,6 @@
 variable "project" {
   type    = string
-  default = "cstar"
+  default = "pagopa"
   validation {
     condition = (
       length(var.project) <= 6


### PR DESCRIPTION
**Description:**
### List of changes
- Replaced hardcoded Helm chart version with a configurable variable `opencost_helm_chart_version`.
- Improved flexibility for updating the Helm chart version without modifying main Terraform code.
- Added a default value for the variable in `99_variables.tf`.

### Motivation and context
This change was made to enhance flexibility in managing the Helm chart version for Opencost deployments. By introducing a configurable variable, it becomes easier to update the version without the need to modify the main Terraform code.

### Type of changes
- [x] Update existing module

### Does this introduce a breaking change?
- [x] No

### Other information
No additional information provided.

### Run checks
Useful commands to run checks on a local machine
```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```