### PR TITLE
feat: [PAYMCLOUD-203] Refactor alert prefix variable and refine event filters

### DIFF
--- a/kubernetes_event_exporter/main.tf
+++ b/kubernetes_event_exporter/main.tf
@@ -13,11 +13,11 @@ resource "helm_release" "helm_this" {
     var.custom_config == null ?
     templatefile("${path.module}/templates/default.tftpl",
       {
+        alert_prefix           = var.alert_prefix
         enable_slack           = var.enable_slack, # SLACK PARAM BELOW
         slack_receiver_name    = var.slack_receiver_name,
         slack_token            = var.slack_token,
         slack_channel          = var.slack_channel,
-        slack_message_prefix   = var.slack_message_prefix,
         slack_title            = var.slack_title,
         slack_author           = var.slack_author,
         enable_opsgenie        = var.enable_opsgenie, # OPSGENIE PARAM BELOW

--- a/kubernetes_event_exporter/templates/default.tftpl
+++ b/kubernetes_event_exporter/templates/default.tftpl
@@ -10,7 +10,7 @@ config:
       slack:
         token: "${slack_token}"
         channel: "${slack_channel}"
-        message: "${slack_message_prefix} {{ .Message }}"
+        message: "${alert_prefix} {{ .Message }}"
         title: "${slack_title}"
         author_name: "${slack_author}"
         fields:
@@ -24,7 +24,7 @@ config:
       opsgenie:
         apiKey: "${opsgenie_api_key}"
         priority: "P3"
-        message: "[INFRA-pagoPa][AKS Sev3] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
+        message: "[${alert_prefix}][AKS Sev3] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
         alias: "{{ .UID }}"
         description: "<pre>{{ toPrettyJson . }}</pre>"
         tags:
@@ -36,7 +36,7 @@ config:
       opsgenie:
         apiKey: "${opsgenie_api_key}"
         priority: "P1"
-        message: "[INFRA-pagoPa][AKS Sev1] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
+        message: "[${alert_prefix}][AKS Sev1] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
         alias: "{{ .UID }}"
         description: "<pre>{{ toPrettyJson . }}</pre>"
         tags:
@@ -52,11 +52,17 @@ config:
       %{ if enable_slack }
       - drop:
         - reason: "Unhealthy"
+        - kind: "HorizontalPodAutoscaler"
+        - kind: "ScaledObjectCheckFailed"
         - reason: "FailedToUpdateEndpoint"
         - reason: "FailedScheduling"
         - reason: "EgressBlocked"
-        - kind: "HorizontalPodAutoscaler"
-        - kind: "ScaledObjectCheckFailed"
+        - reason: "OOMKilling"
+        - reason: "RebootScheduled"
+        - reason: "RedeployScheduled"
+        - reason: "FreezeScheduled"
+        - reason: "TerminateScheduled"
+        - reason: "PreemptScheduled"
         match:
           - receiver: "slack"
             type: "Warning"
@@ -66,6 +72,24 @@ config:
             reason: "NotTriggerScaleUp"
       %{ endif }
       %{ if enable_opsgenie }
+ - drop:
+        - reason: "Unhealthy"
+        - kind: "HorizontalPodAutoscaler"
+        - kind: "ScaledObjectCheckFailed"
+        - reason: "FailedToUpdateEndpoint"
+        - reason: "FailedScheduling"
+        - reason: "EgressBlocked"
+        - reason: "OOMKilling"
+        - reason: "RebootScheduled"
+        - reason: "RedeployScheduled"
+        - reason: "FreezeScheduled"
+        - reason: "TerminateScheduled"
+        - reason: "PreemptScheduled"
+        match:
+          - receiver: "${opsgenie_receiver_name}-critical"
+            type: "Warning"
+          - receiver: "${opsgenie_receiver_name}-critical"
+            reason: "Failed"
       - drop:
         - reason: "Unhealthy"
         - kind: "HorizontalPodAutoscaler"
@@ -77,11 +101,14 @@ config:
           - receiver: ${opsgenie_receiver_name}-warning
             reason: "OOMKilling"
           - receiver: ${opsgenie_receiver_name}-warning
-            reason: "*Scheduled"
-          - receiver: "${opsgenie_receiver_name}-critical"
-            type: "Warning"
-          - receiver: "${opsgenie_receiver_name}-critical"
-            reason: "*Failed*"
-          - receiver: "${opsgenie_receiver_name}-critical"
-            reason: "NotTriggerScaleUp"
-      %{ endif }
+            reason: "RebootScheduled"
+          - receiver: ${opsgenie_receiver_name}-warning
+            reason: "RedeployScheduled"
+          - receiver: ${opsgenie_receiver_name}-warning
+            reason: "FreezeScheduled"
+          - receiver: ${opsgenie_receiver_name}-warning
+            reason: "TerminateScheduled"
+          - receiver: ${opsgenie_receiver_name}-warning
+            reason: "PreemptScheduled"
+          - receiver: "${opsgenie_receiver_name}-warning"
+            reason: "NotTriggerScaleUp"      %{ endif }

--- a/kubernetes_event_exporter/templates/default.tftpl
+++ b/kubernetes_event_exporter/templates/default.tftpl
@@ -24,7 +24,7 @@ config:
       opsgenie:
         apiKey: "${opsgenie_api_key}"
         priority: "P3"
-        message: "[${alert_prefix}][AKS Sev3] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
+        message: "${alert_prefix}[Sev3] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
         alias: "{{ .UID }}"
         description: "<pre>{{ toPrettyJson . }}</pre>"
         tags:
@@ -36,7 +36,7 @@ config:
       opsgenie:
         apiKey: "${opsgenie_api_key}"
         priority: "P1"
-        message: "[${alert_prefix}][AKS Sev1] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
+        message: "${alert_prefix}[Sev1] {{ .Reason }} for {{ .InvolvedObject.Namespace }}/{{ .InvolvedObject.Name }} on K8s cluster"
         alias: "{{ .UID }}"
         description: "<pre>{{ toPrettyJson . }}</pre>"
         tags:

--- a/kubernetes_event_exporter/templates/default.tftpl
+++ b/kubernetes_event_exporter/templates/default.tftpl
@@ -72,7 +72,7 @@ config:
             reason: "NotTriggerScaleUp"
       %{ endif }
       %{ if enable_opsgenie }
- - drop:
+      - drop:
         - reason: "Unhealthy"
         - kind: "HorizontalPodAutoscaler"
         - kind: "ScaledObjectCheckFailed"
@@ -111,4 +111,5 @@ config:
           - receiver: ${opsgenie_receiver_name}-warning
             reason: "PreemptScheduled"
           - receiver: "${opsgenie_receiver_name}-warning"
-            reason: "NotTriggerScaleUp"      %{ endif }
+            reason: "NotTriggerScaleUp"
+        %{ endif }

--- a/kubernetes_event_exporter/variables.tf
+++ b/kubernetes_event_exporter/variables.tf
@@ -31,6 +31,15 @@ variable "custom_variables" {
 }
 
 #
+# ⚠️ General alert parameters
+#
+variable "alert_prefix" {
+  type        = string
+  description = "(Optional) Formatting the message prefix of your alert."
+  default     = "pagoPa"
+}
+
+#
 # 💬 SLACK Parameters
 #
 
@@ -54,12 +63,6 @@ variable "slack_token" {
 variable "slack_channel" {
   type        = string
   description = "(Optional) Slack channel for receive messages from exporter."
-}
-
-variable "slack_message_prefix" {
-  type        = string
-  description = "(Optional) Formatting the message prefix of your slack alert."
-  default     = "Received a Kubernetes Event:"
 }
 
 variable "slack_title" {


### PR DESCRIPTION
Replaced `slack_message_prefix` with a more generic `alert_prefix` variable for greater consistency across alerts. Updated templates and conditions to apply the new variable and extended filtering rules for both Slack and OpsGenie to refine dropped and matched Kubernetes event reasons.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Refactor `slack_message_prefix` to `alert_prefix` for consistency in alerts, with extended filtering for Kubernetes events.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
