### PR TITLE
feat: [PAYMCLOUD-203] Set default values for Slack token and channel variables

### DIFF
--- a/kubernetes_event_exporter/variables.tf
+++ b/kubernetes_event_exporter/variables.tf
@@ -58,11 +58,13 @@ variable "slack_receiver_name" {
 variable "slack_token" {
   type        = string
   description = "(Optional) Slack app token to be able to connect on your workspace and send messages."
+  default     = ""
 }
 
 variable "slack_channel" {
   type        = string
   description = "(Optional) Slack channel for receive messages from exporter."
+  default     = "#alerts"
 }
 
 variable "slack_title" {


### PR DESCRIPTION
Added default values to the `slack_token` and `slack_channel` variables to improve usability and prevent undefined variable errors. These defaults ensure smoother configuration and setup for the Kubernetes Event Exporter.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Added default values to the `slack_token` and `slack_channel` variables for improved usability and error prevention in configuring the Kubernetes Event Exporter.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
