### PR TITLE
feat: [PAYMCLOUD-263] Add azapi provider and Grafana private endpoint in Terraform

### DIFF
--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -134,7 +134,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
 # # Approve the private endpoint
 resource "azapi_update_resource" "approval" {
-  type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
+  type      = "Microsoft.Network/privateEndpoints/privateEndpointConnections@2023-10-01-preview"
   name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
   parent_id = azapi_resource.grafana_managed_private_endpoint_ma.body.properties.privateLinkResourceId
 

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -147,7 +147,7 @@ resource "azapi_update_resource" "auto_approve_private_endpoint" {
     }
   }
 
-  lifecycle {
-    ignore_changes = all
-  }
+  # lifecycle {
+  #   ignore_changes = all
+  # }
 }

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -121,8 +121,8 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
       ]
       privateLinkResourceId     = data.azurerm_monitor_workspace.this.id
       privateLinkResourceRegion = data.azurerm_monitor_workspace.this.location
-      privateLinkServiceUrl     = replace(data.azurerm_monitor_workspace.this.query_endpoint, "https://", "")
-      requestMessage            = "approval"
+      # privateLinkServiceUrl     = replace(data.azurerm_monitor_workspace.this.query_endpoint, "https://", "")
+      requestMessage = "approval"
     }
   }
 

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -110,7 +110,7 @@ resource "azurerm_role_assignment" "datareaderrole" {
 # https://registry.terraform.io/providers/hashicorp/azurerm/4.9.0/docs/resources/dashboard_grafana_managed_private_endpoint
 resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
   type      = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2023-10-01-preview"
-  name      = "pagopa${var.tags["Environment"]}${var.location_short}GrafanaPam"
+  name      = "pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
   location  = var.location
   tags      = var.tags
   parent_id = data.azurerm_dashboard_grafana.grafana.id

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -131,22 +131,3 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }
-
-# # Approve the private endpoint
-resource "azapi_update_resource" "approval" {
-  type      = "Microsoft.Network/privateEndpoints/privateEndpointConnections@2023-09-01"
-  name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
-  parent_id = azapi_resource.grafana_managed_private_endpoint_ma.body.properties.privateLinkResourceId
-
-  body = {
-    properties = {
-      privateLinkServiceConnectionState = {
-        description = "Approved via Terraform"
-        status      = "Approved"
-      }
-    }
-  }
-  lifecycle {
-    ignore_changes = all
-  }
-}

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -123,6 +123,10 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
       privateLinkResourceRegion = data.azurerm_monitor_workspace.this.location
       requestMessage            = "Approved"
     }
+
+  }
+  lifecycle {
+    ignore_changes = [tags]
   }
 
   depends_on = [data.azurerm_monitor_workspace.this]
@@ -132,7 +136,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 resource "azapi_update_resource" "approval" {
   type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
   name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
-  parent_id = azapi_resource.grafana_managed_private_endpoint_ma.parent_id
+  parent_id = azapi_resource.grafana_managed_private_endpoint_ma.id
 
   body = {
     properties = {
@@ -141,5 +145,8 @@ resource "azapi_update_resource" "approval" {
         status      = "Approved"
       }
     }
+  }
+  lifecycle {
+    ignore_changes = all
   }
 }

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -123,27 +123,23 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
       privateLinkResourceRegion = data.azurerm_monitor_workspace.this.location
       requestMessage            = "Approved"
     }
-    connectionState = {
-      description = "Approved via Terraform"
-      status      = "Approved"
-    }
   }
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }
 
 # # Approve the private endpoint
-# resource "azapi_update_resource" "approval" {
-#   type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
-#   name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
-#   parent_id = data.azurerm_monitor_workspace.this.id
-#
-#   body = {
-#     properties = {
-#       privateLinkServiceConnectionState = {
-#         description = "Approved via Terraform"
-#         status      = "Approved"
-#       }
-#     }
-#   }
-# }
+resource "azapi_update_resource" "approval" {
+  type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
+  name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
+  parent_id = azapi_resource.grafana_managed_private_endpoint_ma.parent_id
+
+  body = {
+    properties = {
+      privateLinkServiceConnectionState = {
+        description = "Approved via Terraform"
+        status      = "Approved"
+      }
+    }
+  }
+}

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -128,3 +128,19 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }
+
+# Approve the private endpoint
+resource "azapi_update_resource" "approval" {
+  type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
+  name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
+  parent_id = data.azurerm_monitor_workspace.this.id
+
+  body = {
+    properties = {
+      privateLinkServiceConnectionState = {
+        description = "Approved via Terraform"
+        status      = "Approved"
+      }
+    }
+  }
+}

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -131,3 +131,21 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }
+
+
+# Auto Approve il Private Endpoint
+resource "azapi_update_resource" "auto_approve_private_endpoint" {
+  type        = "Microsoft.Dashboard/grafana/privateLinkResources@2023-10-01-preview"
+  resource_id = azapi_resource.grafana_managed_private_endpoint_ma.id
+
+  body = {
+    properties = {
+      autoApproval = {
+        subscriptionId = data.azurerm_dashboard_grafana.grafana.id
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -135,7 +135,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
 # Auto Approve il Private Endpoint
 resource "azapi_update_resource" "auto_approve_private_endpoint" {
-  type        = "Microsoft.Dashboard/grafana/privateLinkResources@2023-10-01-preview"
+  type        = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2023-10-01-preview"
   resource_id = azapi_resource.grafana_managed_private_endpoint_ma.id
 
   body = {

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -134,7 +134,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
 # # Approve the private endpoint
 resource "azapi_update_resource" "approval" {
-  type      = "Microsoft.Network/privateEndpoints/privateEndpointConnections@2023-10-01-preview"
+  type      = "Microsoft.Network/privateEndpoints/privateEndpointConnections@2023-09-01"
   name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
   parent_id = azapi_resource.grafana_managed_private_endpoint_ma.body.properties.privateLinkResourceId
 

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -121,7 +121,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
       ]
       privateLinkResourceId     = data.azurerm_monitor_workspace.this.id
       privateLinkResourceRegion = data.azurerm_monitor_workspace.this.location
-      privateLinkServiceUrl     = data.azurerm_monitor_workspace.this.query_endpoint
+      privateLinkServiceUrl     = replace(data.azurerm_monitor_workspace.this.query_endpoint, "https://", "")
       requestMessage            = "approval"
     }
   }

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -109,7 +109,7 @@ resource "azurerm_role_assignment" "datareaderrole" {
 # TODO Azure azurerm_dashboard_grafana_managed_private_endpoint release after v4.9.0 of azurerm provider
 # https://registry.terraform.io/providers/hashicorp/azurerm/4.9.0/docs/resources/dashboard_grafana_managed_private_endpoint
 resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
-  type      = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2024-10-01"
+  type      = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2023-10-01-preview"
   name      = "pagopa${var.tags["Environment"]}${var.location_short}GrafanaPam"
   location  = var.location
   tags      = var.tags

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -106,13 +106,15 @@ resource "azurerm_role_assignment" "datareaderrole" {
   principal_id       = data.azurerm_dashboard_grafana.grafana.identity.0.principal_id
 }
 
+# TODO Azure azurerm_dashboard_grafana_managed_private_endpoint release after v4.9.0 of azurerm provider
+# https://registry.terraform.io/providers/hashicorp/azurerm/4.9.0/docs/resources/dashboard_grafana_managed_private_endpoint
 resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
   type      = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2024-10-01"
   name      = "pagopa${var.tags["Environment"]}${var.location_short}GrafanaPam"
   location  = var.location
   tags      = var.tags
   parent_id = data.azurerm_dashboard_grafana.grafana.id
-  body = jsonencode({
+  body = {
     properties = {
       groupIds = [
         "prometheusMetrics"
@@ -122,7 +124,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
       privateLinkServiceUrl     = data.azurerm_monitor_workspace.this.query_endpoint
       requestMessage            = "approval"
     }
-  })
+  }
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -136,7 +136,7 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 resource "azapi_update_resource" "approval" {
   type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
   name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
-  parent_id = azapi_resource.grafana_managed_private_endpoint_ma.id
+  parent_id = azapi_resource.grafana_managed_private_endpoint_ma.body.properties.privateLinkResourceId
 
   body = {
     properties = {

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -140,11 +140,13 @@ resource "azapi_update_resource" "auto_approve_private_endpoint" {
 
   body = {
     properties = {
-      autoApproval = {
-        subscriptionId = data.azurerm_dashboard_grafana.grafana.id
+      privateLinkServiceConnectionState = {
+        status      = "Approved"
+        description = "Auto-approved managed private endpoint"
       }
     }
   }
+
   lifecycle {
     ignore_changes = all
   }

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -131,23 +131,3 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }
-
-
-# Auto Approve il Private Endpoint
-resource "azapi_update_resource" "auto_approve_private_endpoint" {
-  type        = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2023-10-01-preview"
-  resource_id = azapi_resource.grafana_managed_private_endpoint_ma.id
-
-  body = {
-    properties = {
-      privateLinkServiceConnectionState = {
-        status      = "Approved"
-        description = "Auto-approved managed private endpoint"
-      }
-    }
-  }
-
-  # lifecycle {
-  #   ignore_changes = all
-  # }
-}

--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -121,26 +121,29 @@ resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
       ]
       privateLinkResourceId     = data.azurerm_monitor_workspace.this.id
       privateLinkResourceRegion = data.azurerm_monitor_workspace.this.location
-      # privateLinkServiceUrl     = replace(data.azurerm_monitor_workspace.this.query_endpoint, "https://", "")
-      requestMessage = "approval"
+      requestMessage            = "Approved"
+    }
+    connectionState = {
+      description = "Approved via Terraform"
+      status      = "Approved"
     }
   }
 
   depends_on = [data.azurerm_monitor_workspace.this]
 }
 
-# Approve the private endpoint
-resource "azapi_update_resource" "approval" {
-  type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
-  name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
-  parent_id = data.azurerm_monitor_workspace.this.id
-
-  body = {
-    properties = {
-      privateLinkServiceConnectionState = {
-        description = "Approved via Terraform"
-        status      = "Approved"
-      }
-    }
-  }
-}
+# # Approve the private endpoint
+# resource "azapi_update_resource" "approval" {
+#   type      = "Microsoft.Dashboard/grafana/privateEndpointConnections@2023-10-01-preview"
+#   name      = "grafana-${data.azurerm_dashboard_grafana.grafana.name}-pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
+#   parent_id = data.azurerm_monitor_workspace.this.id
+#
+#   body = {
+#     properties = {
+#       privateLinkServiceConnectionState = {
+#         description = "Approved via Terraform"
+#         status      = "Approved"
+#       }
+#     }
+#   }
+# }

--- a/kubernetes_prometheus_managed/99_variables.tf
+++ b/kubernetes_prometheus_managed/99_variables.tf
@@ -7,6 +7,17 @@ variable "location" {
   type = string
 }
 
+variable "location_short" {
+  type = string
+  validation {
+    condition = (
+      length(var.location_short) == 3
+    )
+    error_message = "Length must be 3 chars."
+  }
+  description = "One of wue, neu"
+}
+
 variable "cluster_name" {
   description = "The name of the Kubernetes cluster."
   type        = string

--- a/kubernetes_prometheus_managed/99_versions.tf
+++ b/kubernetes_prometheus_managed/99_versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>3.105"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "2.2.0"
+    }
   }
 }


### PR DESCRIPTION
### List of changes

- Add azapi provider for Azure resource provisioning in Terraform.
- Introduce a Grafana managed private endpoint resource.
- Validate the new `location_short` variable for uniformity.
- Configure private link properties for Prometheus metrics integration.

### Motivation and context

This PR enables the use of the azapi provider for better Azure resource management. It also sets up a Grafana private endpoint to securely manage Prometheus metrics integration. The introduction of `location_short` ensures standardized variable usage.

### Type of changes

- [x] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

None. 

### Run checks

Useful commands to run checks on the local machine:

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a