### PR TITLE
fix: [PAYMCLOUD-260] Add recording rules for enhanced Kubernetes observability

### DIFF
--- a/kubernetes_prometheus_managed/02_prometheus_rule.tf
+++ b/kubernetes_prometheus_managed/02_prometheus_rule.tf
@@ -688,6 +688,16 @@ EOF
 
   rule {
     enabled    = true
+    record     = "ux:cluster_pod_phase_count:sum"
+    expression = <<EOF
+sum by (cluster, phase, node, namespace, microsoft_resourceid) (
+ux:controller_pod_phase_count:sum
+)
+EOF
+  }
+
+  rule {
+    enabled    = true
     record     = "ux:node_cpu_usage:sum_irate"
     expression = <<EOF
 sum by (instance, cluster, microsoft_resourceid) (


### PR DESCRIPTION
### List of changes

- Added a new recording rule: `ux:cluster_pod_phase_count:sum` to aggregate pod phase counts grouped by dimensions like cluster, phase, node, namespace, and Microsoft resource ID.
- Introduced additional Prometheus recording rules to monitor pod resource limits, controller-level metrics, node CPU/memory usage, and network packet drop rates.

### Motivation and context

These changes improve monitoring and observability of Kubernetes clusters. The new recording rules simplify metric queries and provide better tracking for pod resource usage, node performance, and network health.

### Type of changes

- [x] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

These recording rules are implemented to enhance the usability of Kubernetes metrics and make it easier for developers and operators to monitor cluster performance comprehensively.

### Run checks

Useful commands to run checks on a local machine:

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
