### PR TITLE
feat: [PAYMCLOUD-255] Add support for custom Grafana deployment region

### DIFF
--- a/kubernetes_prometheus_managed/01_main.tf
+++ b/kubernetes_prometheus_managed/01_main.tf
@@ -111,7 +111,7 @@ resource "azurerm_role_assignment" "datareaderrole" {
 resource "azapi_resource" "grafana_managed_private_endpoint_ma" {
   type      = "Microsoft.Dashboard/grafana/managedPrivateEndpoints@2023-10-01-preview"
   name      = "pagopa${var.tags["Environment"]}${var.location_short}GrafPam"
-  location  = var.location
+  location  = var.custom_gf_location != null ? var.custom_gf_location : var.location
   tags      = var.tags
   parent_id = data.azurerm_dashboard_grafana.grafana.id
   body = {

--- a/kubernetes_prometheus_managed/99_variables.tf
+++ b/kubernetes_prometheus_managed/99_variables.tf
@@ -68,6 +68,12 @@ variable "grafana_resource_group" {
   type        = string
 }
 
+variable "custom_gf_location" {
+  description = "The Azure region where Grafana is deployed."
+  type        = string
+  default     = null
+}
+
 variable "action_groups_id" {
   description = "The ID of the Action Group to use for the Alerts."
   type        = list(string)


### PR DESCRIPTION
### List of changes

- Added a new variable `custom_gf_location` to specify a custom Azure region for Grafana deployments.
- Updated the Grafana resource to use this variable if specified; otherwise, the default region is used to maintain backward compatibility.

### Motivation and context

This change allows users to deploy Grafana resources in a specific Azure region as per their requirements. It provides more flexibility and adaptability while ensuring compatibility with existing setups.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine:

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```