### PR TITLE
fix: Disable dynamic maintenance window configuration

### DIFF
--- a/kubernetes_cluster_udr/01_main.tf
+++ b/kubernetes_cluster_udr/01_main.tf
@@ -111,20 +111,20 @@ resource "azurerm_kubernetes_cluster" "this" {
     }
   }
 
-  dynamic "maintenance_window_node_os" {
-    for_each = var.maintenance_windows_node_os.enabled ? [1] : []
-    content {
-      day_of_month = var.maintenance_windows_node_os.day_of_month
-      day_of_week  = var.maintenance_windows_node_os.day_of_week
-      duration     = var.maintenance_windows_node_os.duration
-      frequency    = var.maintenance_windows_node_os.frequency
-      interval     = var.maintenance_windows_node_os.interval
-      start_date   = var.maintenance_windows_node_os.start_date
-      start_time   = var.maintenance_windows_node_os.start_time
-      utc_offset   = var.maintenance_windows_node_os.utc_offset
-      week_index   = var.maintenance_windows_node_os.week_index
-    }
-  }
+  # dynamic "maintenance_window_node_os" {
+  #   for_each = var.maintenance_windows_node_os.enabled ? [1] : []
+  #   content {
+  #     day_of_month = var.maintenance_windows_node_os.day_of_month
+  #     day_of_week  = var.maintenance_windows_node_os.day_of_week
+  #     duration     = var.maintenance_windows_node_os.duration
+  #     frequency    = var.maintenance_windows_node_os.frequency
+  #     interval     = var.maintenance_windows_node_os.interval
+  #     start_date   = var.maintenance_windows_node_os.start_date
+  #     start_time   = var.maintenance_windows_node_os.start_time
+  #     utc_offset   = var.maintenance_windows_node_os.utc_offset
+  #     week_index   = var.maintenance_windows_node_os.week_index
+  #   }
+  # }
 
   role_based_access_control_enabled = true
   azure_active_directory_role_based_access_control {


### PR DESCRIPTION
### List of changes

- Commented out the dynamic block for `maintenance_window_node_os` in the Terraform configuration to disable the associated configuration. This change retains the code structure for potential future use, testing, or debugging.

### Motivation and context

- This change is intended to disable the dynamic maintenance window configuration temporarily while preserving the existing code for possible future needs.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```