### PR TITLE
chore: [IOPID-3868] New CDN

### DIFF
--- a/cdn/README.md
+++ b/cdn/README.md
@@ -67,7 +67,7 @@ module "devopslab_cdn" {
       {
         action = "Append"
         name   = "Content-Security-Policy-Report-Only"
-        value  = "img-src 'self' https://assets.cdn.io.italia.it data:; "
+        value  = "img-src 'self' https://assets.io.pagopa.it data:; "
       }
     ]
   }


### PR DESCRIPTION
## Short description
This PR updates an old CDN url to the new one (from `assets.cdn.io.(pagopa|italia).it` to `assets.io.pagopa.it`)